### PR TITLE
Override key `%s/JAVA_PACKAGE_PREFIX/JAVA_PACKAGE`

### DIFF
--- a/docs/generate/managed-mode.md
+++ b/docs/generate/managed-mode.md
@@ -79,7 +79,7 @@ managed:
     override:
       buf.build/acme/weather: github.com/acme/weather/gen/proto/go
   override:
-    JAVA_PACKAGE_PREFIX:
+    JAVA_PACKAGE:
       acme/weather/v1/weather.proto: "org"
 plugins:
   - name: go


### PR DESCRIPTION
The correct key for the override for the `java_package` option is `JAVA_PACKAGE`.