### PR TITLE
Buf tour updates

### DIFF
--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -97,16 +97,29 @@ The above command should have exit code 0 and no output. This means that all of 
 defined in the current directory successfully compile.
 
 Plus, you can see some interesting details about the compiled artifact with a few flags and
-[jq](https://stedolan.github.io/jq):
+[jq](https://stedolan.github.io/jq). This command displays a list of the Protobuf packages used
+in this project:
 
 ```terminal
-$ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package' | sort | uniq | head
+$ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package'
+```
+
+The output you should see:
+
+```terminal
 "google.protobuf"
 "google.type"
 "pet.v1"
 ```
 
-In this case, we see three packages: the [Well-Known Types](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf),
-a dependency on a `google` API, and the `pet.v1` API itself. We'll come back to this later.
+That output indicates that these packages are used in the project:
+
+Package name | Meaning
+:------------|:-------
+`google.protobuf` | A dependency on the [Well-Known Types](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf)
+`google.type` | A dependency on a Google API
+`pet.v1` | The pet store API itself
+
+We'll come back to the `pet.v1` package later.
 
 [tour_repo]: https://github.com/bufbuild/buf-tour.git

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -93,8 +93,9 @@ Before we continue, let's verify that everything is set up properly:
 $ buf build
 ```
 
-The above command should have exit code 0 and no output. This means that all of the `.proto` files
-defined in the current directory successfully compile.
+The above command should have exit code 0 and no output (you can check the exit code by
+running `echo $?`). This means that all of the `.proto` files defined in the current
+directory successfully compile.
 
 Plus, you can see some interesting details about the compiled artifact with a few flags and
 [jq](https://stedolan.github.io/jq). This command displays a list of the Protobuf packages used
@@ -104,15 +105,7 @@ in this project:
 $ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package'
 ```
 
-The output you should see:
-
-```terminal
-"google.protobuf"
-"google.type"
-"pet.v1"
-```
-
-That output indicates that these packages are used in the project:
+The output indicates that these packages are used in the project:
 
 Package name | Meaning
 :------------|:-------

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -103,9 +103,13 @@ in this project:
 
 ```terminal
 $ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package'
+---
+"google.protobuf"
+"google.type"
+"pet.v1"
 ```
 
-The output indicates that these packages are used in the project:
+As you can see from the output, these packages are used in the project:
 
 Package name | Meaning
 :------------|:-------
@@ -114,5 +118,6 @@ Package name | Meaning
 `pet.v1` | The pet store API itself
 
 We'll come back to the `pet.v1` package later.
+
 
 [tour_repo]: https://github.com/bufbuild/buf-tour.git

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -6,8 +6,9 @@ title: 1 Configure and Build
 We'll start our tour by configuring `buf` and building the `.proto` files that define
 the pet store API, which specifies a way to create, get, and delete pets in the store.
 
-Clone the [`bufbuild/buf-tour`][tour_repo] repository from GitHub and navigate to the
-`petapis` directory, which contains the pet store's `.proto` files:
+Clone the [`bufbuild/buf-tour`](https://github.com/bufbuild/buf-tour.git) repository
+from GitHub and navigate to the `petapis` directory, which contains the pet store's
+`.proto` files:
 
 ```terminal
 $ git clone https://github.com/bufbuild/buf-tour.git
@@ -118,6 +119,3 @@ Package name | Meaning
 `pet.v1` | The pet store API itself
 
 We'll come back to the `pet.v1` package later.
-
-
-[tour_repo]: https://github.com/bufbuild/buf-tour.git

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -6,12 +6,12 @@ title: 1 Configure and Build
 We'll start our tour by configuring `buf` and building the `.proto` files that define
 the pet store API, which specifies a way to create, get, and delete pets in the store.
 
-You're expected to be in the `start` directory of the [https://github.com/bufbuild/buf-tour.git](https://github.com/bufbuild/buf-tour.git)
-repository. From here, move into the `petapis` directory, which contains the pet store's
-`.proto` files.
+Clone the [`bufbuild/buf-tour`][tour_repo] repository from GitHub and navigate to the
+`petapis` directory, which contains the pet store's `.proto` files:
 
 ```terminal
-$ cd petapis
+$ git clone https://github.com/bufbuild/buf-tour.git
+$ cd buf-tour/start/petapias
 ```
 
 ## 1.1 Configure `buf` {#configure-buf}
@@ -108,3 +108,5 @@ $ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package' | s
 
 In this case, we see three packages: the [Well-Known Types](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf),
 a dependency on a `google` API, and the `pet.v1` API itself. We'll come back to this later.
+
+[tour_repo]: https://github.com/bufbuild/buf-tour.git

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -11,7 +11,7 @@ Clone the [`bufbuild/buf-tour`][tour_repo] repository from GitHub and navigate t
 
 ```terminal
 $ git clone https://github.com/bufbuild/buf-tour.git
-$ cd buf-tour/start/petapias
+$ cd buf-tour/start/petapis
 ```
 
 ## 1.1 Configure `buf` {#configure-buf}

--- a/docs/tour/introduction.md
+++ b/docs/tour/introduction.md
@@ -31,15 +31,15 @@ $ buf protoc --help
 
 ## Clone the Git Repository {#clone-the-git-repository}
 
-First you need to clone the Git repository that contains the starter code for the `PetStore` service.
+First, clone the Git repository that contains the starter code for the `PetStore` service.
 From the development directory of your choice, run the following command:
 
 ```terminal
-$ git clone git@github.com:bufbuild/buf-tour.git
+$ git clone https://github.com/bufbuild/buf-tour
 ```
 
 You'll notice that the repository contains a `start` directory and a `finish` directory. During the tour
-you'll work on files in the `start` directory, and at the end they'll match the files in the `finish` directory.
+you'll work on files in the `start` directory, and at the end they should match the files in the `finish` directory.
 
 ```sh
 buf-tour/
@@ -85,7 +85,7 @@ buf-tour/
                 └── pet.proto
 ```
 
-To begin, move into the `start` directory, and continue to the next step:
+To begin, move into the `start` directory and continue to the next step:
 
 ```terminal
 $ cd buf-tour/start

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -39,7 +39,7 @@ $ buf lint --error-format=json
 
 ## 3.1 Lint Exceptions {#lint-exceptions}
 
-The [`DEFAULT`](/lint/rules#default) lint category failures we're seeing come from these rules:
+The [`DEFAULT`](/lint/rules#default) lint category failures come from these rules:
 
 * [`PACKAGE_VERSION_SUFFIX`](../lint/rules.md#package_version_suffix)
 * [`FIELD_LOWER_SNAKE_CASE`](../lint/rules.md#field_lower_snake_case)

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -7,18 +7,14 @@ You can run all of the configured lint rules with the following:
 
 ```terminal
 $ buf lint
+```
+
+The output:
+
+```
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
 pet/v1/pet.proto:44:10:Field name "petID" should be lower_snake_case, such as "pet_id".
 pet/v1/pet.proto:49:9:Service name "PetStore" should be suffixed with "Service".
-```
-
-You can also output this as JSON:
-
-```terminal
-$ buf lint --error-format=json
-{"path":"google/type/datetime.proto","start_line":17,"start_column":1,"end_line":17,"end_column":21,"type":"PACKAGE_VERSION_SUFFIX","message":"Package name \"google.type\" should be suffixed with a correctly formed version, such as \"google.type.v1\"."}
-{"path":"pet/v1/pet.proto","start_line":44,"start_column":10,"end_line":44,"end_column":15,"type":"FIELD_LOWER_SNAKE_CASE","message":"Field name \"petID\" should be lower_snake_case, such as \"pet_id\"."}
-{"path":"pet/v1/pet.proto","start_line":49,"start_column":9,"end_line":49,"end_column":17,"type":"SERVICE_SUFFIX","message":"Service name \"PetStore\" should be suffixed with \"Service\"."}
 ```
 
 As you can see, the current pet store API has a few lint failures across both of its
@@ -35,15 +31,30 @@ breaking:
     - FILE
 ```
 
+You can also output lint failures as JSON:
+
+```terminal
+$ buf lint --error-format=json
+```
+
+The output:
+
+```json
+{"path":"google/type/datetime.proto","start_line":17,"start_column":1,"end_line":17,"end_column":21,"type":"PACKAGE_VERSION_SUFFIX","message":"Package name \"google.type\" should be suffixed with a correctly formed version, such as \"google.type.v1\"."}
+{"path":"pet/v1/pet.proto","start_line":44,"start_column":10,"end_line":44,"end_column":15,"type":"FIELD_LOWER_SNAKE_CASE","message":"Field name \"petID\" should be lower_snake_case, such as \"pet_id\"."}
+{"path":"pet/v1/pet.proto","start_line":49,"start_column":9,"end_line":49,"end_column":17,"type":"SERVICE_SUFFIX","message":"Service name \"PetStore\" should be suffixed with \"Service\"."}
+```
+
 ## 3.1 Lint Exceptions {#lint-exceptions}
 
-The `DEFAULT` lint category failures we're seeing come from following rules:
+The [`DEFAULT`](/lint/rules#default) lint category failures we're seeing come from these rules:
 
-  * [`PACKAGE_VERSION_SUFFIX`](../lint/rules.md#package_version_suffix)
-  * [`FIELD_LOWER_SNAKE_CASE`](../lint/rules.md#field_lower_snake_case)
-  * [`SERVICE_SUFFIX`](../lint/rules.md#service_suffix)
+* [`PACKAGE_VERSION_SUFFIX`](../lint/rules.md#package_version_suffix)
+* [`FIELD_LOWER_SNAKE_CASE`](../lint/rules.md#field_lower_snake_case)
+* [`SERVICE_SUFFIX`](../lint/rules.md#service_suffix)
 
-If we want to make `buf` happy, we can exclude these rules from the `DEFAULT` category like so:
+To make `buf` happy, you can exclude these rules from the `DEFAULT` category by adding them to the
+[`except`](/lint/configuration#except) list in your lint configuration:
 
 ```yaml title="buf.yaml" {5-8}
  version: v1
@@ -59,15 +70,16 @@ If we want to make `buf` happy, we can exclude these rules from the `DEFAULT` ca
      - FILE
 ```
 
-Now if we run `buf lint` again, you'll notice that it's successful (i.e. exit code 0 and no output):
+Now if you run `buf lint` again, you'll notice that it's successful (exit code 0 and no output):
 
 ```terminal
 $ buf lint
 ```
 
-However, this isn't actually what we want - we should actually fix the lint failures instead of making
-exceptions. Although `except` is **not recommended**, it's unavoidable in some situations. You can restore
-the `buf.yaml` to its previous state with the following:
+Silencing failures by eliminating lint rules using `except` is usually **not** recommended,
+although it may be unavoidable in some situations; it's almost always better to actually _fix_
+the lint failures. You can restore the `buf.yaml` to its previous state with the following
+config changes:
 
 ```yaml title="buf.yaml" {5-8}
  version: v1
@@ -85,9 +97,9 @@ the `buf.yaml` to its previous state with the following:
 
 ## 3.2 Fix Lint Failures {#fix-lint-failures}
 
-We'll start by fixing the lint failures for the `pet/v1/pet.proto` file, which come from the `FIELD_LOWER_SNAKE_CASE`
-and `SERVICE_SUFFIX` rules. Fortunately, `buf` tells us exactly what we need to do to fix the errors, so we can
-apply the changes with the following:
+Start by fixing the lint failures for the `pet/v1/pet.proto` file, which stem from the `FIELD_LOWER_SNAKE_CASE`
+and `SERVICE_SUFFIX` rules. `buf` indicates exactly what you need to change to fix the errors, so you can
+fix the failures with the following updates:
 
 ```protobuf title="pet/v1/pet.proto" {10-11,16-17}
  syntax = "proto3";
@@ -113,19 +125,24 @@ apply the changes with the following:
  }
 ```
 
-With this, we can verify that two of the failures are resolved:
+You can verify that two of the failures are resolved by linting again:
 
 ```terminal
 $ buf lint
+```
+
+The remaining error:
+
+```
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
 ```
 
 ## 3.3 Ignore Lint Failures {#ignore-lint-failures}
 
-The `google/type/datetime.proto` isn't actually a file we own (it's one of our dependencies, which is provided by
-[googleapis](https://buf.build/googleapis/googleapis)), so we can't simply change its `package` declaration to
-satisfy `buf`'s lint requirements. Fortunately, we can `ignore` the `google/type/datetime.proto` file from
-`buf lint` like so:
+The `google/type/datetime.proto` isn't actually a file in your local project. Instead, it's one of your
+dependencies, provided by [googleapis](https://buf.build/googleapis/googleapis), so you can't change its
+`package` declaration to satisfy `buf`'s lint requirements. You can `ignore` the `google/type/datetime.proto`
+file from `buf lint` like with this config update:
 
 ```yaml title="buf.yaml" {5-6}
  version: v1
@@ -139,12 +156,17 @@ satisfy `buf`'s lint requirements. Fortunately, we can `ignore` the `google/type
      - FILE
 ```
 
-Alternatively, we could specify exactly what rules we ignore with the `ignore_only` configuration. We can output failures
-in a format you can then copy into your `buf.yaml` file. This allows you to ignore all existing lint errors and correct them
-over time:
+Alternatively, you can specify exactly which rules to ignore using the [`ignore_only`](/lint/configuration#ignore_only)
+parameter. You can output failures in a format that you can then copy into your `buf.yaml` file. This allows you to ignore
+all existing lint errors and correct them over time:
 
 ```terminal
 $ buf lint --error-format=config-ignore-yaml
+```
+
+The suggested YAML configuration:
+
+```yaml
 version: v1
 lint:
   ignore_only:
@@ -152,15 +174,20 @@ lint:
       - google/type/datetime.proto
 ```
 
-However, we don't own the `google/type/datetime.proto` file, so it's much easier to `ignore` it altogether.
+In this case, you don't own the `google/type/datetime.proto` file, so it's best to `ignore` it altogether.
 
 ## 3.4 Remote Inputs {#remote-inputs}
 
-The `buf lint` command also works with remote inputs, using the local `buf.yaml` configuration. For example, we can see all
-the original lint failures if we reference a `tar.gz` archive from the `main` branch:
+The `buf lint` command also works with remote inputs, using the local `buf.yaml` configuration. For example, you can see all
+the original lint failures if you reference a `tar.gz` archive from the `main` branch:
 
 ```terminal
 $ buf lint "https://github.com/bufbuild/buf-tour/archive/main.tar.gz#strip_components=1,subdir=start/petapis" --config buf.yaml
+```
+
+This returns two lint failures:
+
+```
 start/petapis/pet/v1/pet.proto:44:10:Field name "petID" should be lower_snake_case, such as "pet_id".
 start/petapis/pet/v1/pet.proto:49:9:Service name "PetStore" should be suffixed with "Service".
 ```

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -7,11 +7,7 @@ You can run all of the configured lint rules with the following:
 
 ```terminal
 $ buf lint
-```
-
-The output:
-
-```
+---
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
 pet/v1/pet.proto:44:10:Field name "petID" should be lower_snake_case, such as "pet_id".
 pet/v1/pet.proto:49:9:Service name "PetStore" should be suffixed with "Service".
@@ -35,11 +31,7 @@ You can also output lint failures as JSON:
 
 ```terminal
 $ buf lint --error-format=json
-```
-
-The output:
-
-```json
+---
 {"path":"google/type/datetime.proto","start_line":17,"start_column":1,"end_line":17,"end_column":21,"type":"PACKAGE_VERSION_SUFFIX","message":"Package name \"google.type\" should be suffixed with a correctly formed version, such as \"google.type.v1\"."}
 {"path":"pet/v1/pet.proto","start_line":44,"start_column":10,"end_line":44,"end_column":15,"type":"FIELD_LOWER_SNAKE_CASE","message":"Field name \"petID\" should be lower_snake_case, such as \"pet_id\"."}
 {"path":"pet/v1/pet.proto","start_line":49,"start_column":9,"end_line":49,"end_column":17,"type":"SERVICE_SUFFIX","message":"Service name \"PetStore\" should be suffixed with \"Service\"."}
@@ -125,15 +117,11 @@ fix the failures with the following updates:
  }
 ```
 
-You can verify that two of the failures are resolved by linting again:
+You can verify that two of the failures are resolved by linting again and seeing only one remaining error:
 
 ```terminal
 $ buf lint
-```
-
-The remaining error:
-
-```
+---
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
 ```
 
@@ -162,11 +150,7 @@ all existing lint errors and correct them over time:
 
 ```terminal
 $ buf lint --error-format=config-ignore-yaml
-```
-
-The suggested YAML configuration:
-
-```yaml
+---
 version: v1
 lint:
   ignore_only:
@@ -183,16 +167,16 @@ the original lint failures if you reference a `tar.gz` archive from the `main` b
 
 ```terminal
 $ buf lint "https://github.com/bufbuild/buf-tour/archive/main.tar.gz#strip_components=1,subdir=start/petapis" --config buf.yaml
-```
-
-This returns two lint failures:
-
-```
+---
 start/petapis/pet/v1/pet.proto:44:10:Field name "petID" should be lower_snake_case, such as "pet_id".
 start/petapis/pet/v1/pet.proto:49:9:Service name "PetStore" should be suffixed with "Service".
 ```
 
-  * The `strip_components` option specifies the number of directories to strip for `tar` or `zip` inputs.
+:::note
+The `strip_components` option specifies the number of directories to strip for `tar` or `zip` inputs.
+:::
 
-> For remote locations that require authentication, see [HTTPS Authentication](../reference/inputs.md#https) and
-> [SSH Authentication](../reference/inputs.md#ssh) for more details.
+:::note Remote authentication
+For remote locations that require authentication, see [HTTPS Authentication](../reference/inputs.md#https) and
+[SSH Authentication](../reference/inputs.md#ssh) for more details.
+:::

--- a/docs/tour/list-all-protobuf-files.md
+++ b/docs/tour/list-all-protobuf-files.md
@@ -8,11 +8,7 @@ You can list all of the `.proto` files managed by `buf` per the
 
 ```terminal
 $ buf ls-files
-```
-
-This prints the following list of files:
-
-```
+---
 google/type/datetime.proto
 pet/v1/pet.proto
 ```
@@ -27,19 +23,17 @@ The `ls-files` command also works with remote inputs, such as the following:
 
 ```terminal
 $ buf ls-files git://github.com/bufbuild/buf-tour.git#branch=main,subdir=start/petapis
+---
+start/petapis/google/type/datetime.proto
+start/petapis/pet/v1/pet.proto
 ```
+
+Some things to note from the remote input:
 
 * The `branch` option specifies the branch to clone for git inputs. In this case, use
   the `main` branch.
 * The `subdir` option specifies a sub-directory to use within a `git`, `tar`, or `zip` input.
   In this case, target the `start/petapis` sub-directory.
-
-That should output this list of `.proto` files:
-
-```
-start/petapis/google/type/datetime.proto
-start/petapis/pet/v1/pet.proto
-```
 
 Here, `buf` is listing the files from a [`git`](/reference/inputs#git) archive, so you'll notice that the result includes the
 `start/petapis/` prefix, which is the relative filepath from the root of the `git` archive.

--- a/docs/tour/list-all-protobuf-files.md
+++ b/docs/tour/list-all-protobuf-files.md
@@ -3,24 +3,22 @@ id: list-all-protobuf-files
 title: 2 List All Protobuf Files
 ---
 
-You can list all of the `.proto` files `buf` is configured to use
-with the following command:
+You can list all of the `.proto` files managed by `buf` per the
+[build configuration](../configuration/v1/buf-yaml#build):
 
 ```terminal
 $ buf ls-files
 ```
 
-This prints this list of `.proto` files managed by `buf` per the
-[build configuration](../configuration/v1/buf-yaml.md#build):
+This prints the following list of files:
 
 ```
 google/type/datetime.proto
 pet/v1/pet.proto
 ```
 
-
 The [`build.excludes`](/configuration/v1/buf-yaml#excludes) parameter
-enables you to remove certain directories from being built, but this is neither
+enables you to prevent certain directories from being built, but this is neither
 necessary nor recommended.
 
 ## 2.1 Remote Inputs {#remote-inputs}
@@ -29,17 +27,22 @@ The `ls-files` command also works with remote inputs, such as the following:
 
 ```terminal
 $ buf ls-files git://github.com/bufbuild/buf-tour.git#branch=main,subdir=start/petapis
+```
+
+* The `branch` option specifies the branch to clone for git inputs. In this case, use
+  the `main` branch.
+* The `subdir` option specifies a sub-directory to use within a `git`, `tar`, or `zip` input.
+  In this case, target the `start/petapis` sub-directory.
+
+That should output this list of `.proto` files:
+
+```
 start/petapis/google/type/datetime.proto
 start/petapis/pet/v1/pet.proto
 ```
 
-  * The `branch` option specifies the branch to clone for git inputs. In this case, we're using
-    the `main` branch.
-  * The `subdir` option specifies a sub-directory to use within a `git`, `tar`, or `zip` input.
-    In this case, we're targeting the `start/petapis` sub-directory.
-
-We're listing the files from a `git` archive, so you'll notice that the result includes the
+Here, `buf` is listing the files from a [`git`](/reference/inputs#git) archive, so you'll notice that the result includes the
 `start/petapis/` prefix, which is the relative filepath from the root of the `git` archive.
 
-More [input formats](../reference/inputs.md) can be used in all of the `buf` commands.
+Several other [input formats](../reference/inputs) can be used in many `buf` commands.
 We'll explore more of these formats in the following sections.

--- a/docs/tour/list-all-protobuf-files.md
+++ b/docs/tour/list-all-protobuf-files.md
@@ -8,14 +8,20 @@ with the following command:
 
 ```terminal
 $ buf ls-files
+```
+
+This prints this list of `.proto` files managed by `buf` per the
+[build configuration](../configuration/v1/buf-yaml.md#build):
+
+```
 google/type/datetime.proto
 pet/v1/pet.proto
 ```
 
-This will print a list of all `.proto` files managed by `buf` per the
-[build configuration](../configuration/v1/buf-yaml.md#build). The `build.excludes` value allows you to
-remove certain directories from being built, but it's not generally
-necessary, nor is it recommended.
+
+The [`build.excludes`](/configuration/v1/buf-yaml#excludes) parameter
+enables you to remove certain directories from being built, but this is neither
+necessary nor recommended.
 
 ## 2.1 Remote Inputs {#remote-inputs}
 


### PR DESCRIPTION
This PR makes some readability updates to the Buf tour. I only covered a few pages here, as I'd prefer to get some initial pushback from folks rather than pressing on. Most notable changes:

* The current tour is a bit confused between "you" and "we." These changes unify the docs around "you."
* I've adopted Docusaurus' built-in syntax for specifying CLI commands and outputs. This enables users to use the **Copy** button to copy only the command and not the output.