### PR TITLE
Add Image component

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,17 @@ All styles live in `src/css/custom.css` and CSS module files in `src/theme/`.
 If a style cannot be manipulated in `custom.css` as required, theme components
 can be [overridden](https://docusaurus.io/docs/2.0.0-beta.3/typescript-support#swizzling-typescript-theme-components)
 and [wrapped](https://docusaurus.io/docs/2.0.0-beta.3/using-themes#wrapping-theme-components).
+
+## Custom components
+
+There are a few custom components that you may find useful when working on the docs:
+
+### `Image`
+
+Use this component for embedding images. Here's an example:
+
+```jsx
+<Image src="/images/weird-al.png" alt="Funniest guy ever" />
+```
+
+Required fields are `alt` and `src`.

--- a/docs/bsr/documentation.mdx
+++ b/docs/bsr/documentation.mdx
@@ -7,7 +7,7 @@ import Image from '@site/src/components/Image';
 
 The BSR comes with complete documentation for your Protobuf files through a browsable UI with syntax highlighting, one click navigation between definitions and references. Navigate to a repository within the BSR and click the **Docs** tab. 
 
-<Image alt="BSR module" src="/img/bsr/gen_docs-3.png" />
+<Image alt="BSR module" src="/img/bsr/gen_docs-3.png" caption="The documentation link in the BSR interface" />
 
 For an example see the `demolab/theweather` module by visiting [https://buf.build/demolab/theweather/docs](https://buf.build/demolab/theweather/docs).
 
@@ -20,7 +20,7 @@ To accomplish this, you add a `buf.md` file to the same directory as your module
 The `buf.md` file is analogous to a GitHub repository's `README.md` and currently supports all of the
 [CommonMark](https://commonmark.org) syntax.
 
-<Image alt="BSR module" src="/img/bsr/gen_docs-2.png" />
+<Image alt="BSR module" src="/img/bsr/gen_docs-2.png" caption="Documentation generated from Markdown" />
 
 ## Package documentation
 
@@ -36,4 +36,4 @@ When sharing packages it is often useful to provide an overview of the package. 
 
 Comments on the package directive are not merged across files. Files are parsed alphabetically, and only the first file with a non-empty comment will be displayed in the generated documentation.
 
-<Image alt="BSR module" src="/img/bsr/gen_docs-1_v2.png" />
+<Image alt="BSR module" src="/img/bsr/gen_docs-1_v2.png" caption="Generated package documentation" />

--- a/docs/bsr/documentation.mdx
+++ b/docs/bsr/documentation.mdx
@@ -4,7 +4,6 @@ title: Generated Documentation
 ---
 
 import Image from '@site/src/components/Image';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The BSR comes with complete documentation for your Protobuf files through a browsable UI with syntax highlighting, one click navigation between definitions and references. Navigate to a repository within the BSR and click the **Docs** tab. 
 

--- a/docs/bsr/documentation.mdx
+++ b/docs/bsr/documentation.mdx
@@ -3,13 +3,12 @@ id: documentation
 title: Generated Documentation
 ---
 
+import Image from '@site/src/components/Image';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The BSR comes with complete documentation for your Protobuf files through a browsable UI with syntax highlighting, one click navigation between definitions and references. Navigate to a repository within the BSR and click the **Docs** tab. 
 
-<div align="center">
-  <img alt="BSR module" src={useBaseUrl('/img/bsr/gen_docs-3.png')}/>
-</div>
+<Image alt="BSR module" src="/img/bsr/gen_docs-3.png" />
 
 For an example see the `demolab/theweather` module by visiting [https://buf.build/demolab/theweather/docs](https://buf.build/demolab/theweather/docs).
 
@@ -22,9 +21,7 @@ To accomplish this, you add a `buf.md` file to the same directory as your module
 The `buf.md` file is analogous to a GitHub repository's `README.md` and currently supports all of the
 [CommonMark](https://commonmark.org) syntax.
 
-<div align="center">
-  <img alt="BSR module" src={useBaseUrl('/img/bsr/gen_docs-2.png')}/>
-</div>
+<Image alt="BSR module" src="/img/bsr/gen_docs-2.png" />
 
 ## Package documentation
 
@@ -40,6 +37,4 @@ When sharing packages it is often useful to provide an overview of the package. 
 
 Comments on the package directive are not merged across files. Files are parsed alphabetically, and only the first file with a non-empty comment will be displayed in the generated documentation.
 
-<div align="center">
-  <img alt="BSR module" src={useBaseUrl('/img/bsr/gen_docs-1_v2.png')}/>
-</div>
+<Image alt="BSR module" src="/img/bsr/gen_docs-1_v2.png" />

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -7,15 +7,20 @@ export const mac = "buf-Darwin-x86_64";
 export const linux = "buf-Linux-x86_64";
 export const windows = "buf-Windows-x86_64.exe";
 
-const DownloadButton = ({children, os }) => {
+type Props = {
+  os: string;
+  children: JSX.Element;
+};
+
+const DownloadButton = ({ children, os }: Props) => {
   // siteConfig and customFields configured in the docusaurus.config.js
   const { siteConfig } = useDocusaurusContext();
   const { downloadRelease } = siteConfig && siteConfig.customFields;
 
   return (
     <a
-        className={`button button--primary button--lg ${styles.bufButton}`}
-        href={`https://github.com/bufbuild/buf/releases/download/v${downloadRelease}/${os}`}
+      className={`button button--primary button--lg ${styles.bufButton}`}
+      href={`https://github.com/bufbuild/buf/releases/download/v${downloadRelease}/${os}`}
     >
       <span className={styles.header}>Download</span>
       {children}

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -5,15 +5,17 @@ type Props = {
   alt: string;
   src: string;
   caption?: string;
+  title?: string; // Browsers display this as a tooltip on hover
 };
 
-const Image = ({ alt, src, caption }: Props) => {
+const Image = ({ alt, src, caption, title }: Props) => {
   const url: string = useBaseUrl(src);
+  const imgTitle: string = title || caption;
 
   return (
     <figure>
       <a href={url} target="_blank">
-        <img alt={alt} src={url} />
+        <img alt={alt} src={url} title={imgTitle} />
       </a>
 
       {caption && (

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+type Props = {
+  alt: string;
+  src: string;
+};
+
+const Image = ({ alt, src }: Props) => {
+  return (
+    <div align="center">
+      <img alt={alt} src={useBaseUrl(src)}/>
+    </div>
+  );
+}
+
+export default Image;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -6,16 +6,18 @@ type Props = {
   src: string;
   caption?: string;
   title?: string; // Browsers display this as a tooltip on hover
+  width?: number;
 };
 
-const Image = ({ alt, src, caption, title }: Props) => {
+const Image = ({ alt, src, caption, title, width }: Props) => {
   const url: string = useBaseUrl(src);
   const imgTitle: string = title || caption;
+  const imgWidth: number = width || 100;
 
   return (
     <figure>
       <a href={url} target="_blank">
-        <img alt={alt} src={url} title={imgTitle} />
+        <img alt={alt} src={url} title={imgTitle} width={`${imgWidth}%`} />
       </a>
 
       {caption && (

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -4,13 +4,24 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 type Props = {
   alt: string;
   src: string;
+  caption?: string;
 };
 
-const Image = ({ alt, src }: Props) => {
+const Image = ({ alt, src, caption }: Props) => {
+  const url: string = useBaseUrl(src);
+
   return (
-    <div align="center">
-      <img alt={alt} src={useBaseUrl(src)}/>
-    </div>
+    <figure>
+      <a href={url} target="_blank">
+        <img alt={alt} src={url} />
+      </a>
+
+      {caption && (
+        <figcaption>
+          {caption}
+        </figcaption>
+      )}
+    </figure>
   );
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -89,3 +89,9 @@ h1, h2, h3, h4, h5, h6 {
 html[data-theme='dark'] .docusaurus-highlight-code-line {
     background-color: rgba(0, 0, 0, 0.3);
 }
+
+figcaption {
+    font-weight: 100;
+    font-size: 1.2rem;
+    text-align: right;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -90,6 +90,10 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     background-color: rgba(0, 0, 0, 0.3);
 }
 
+figure {
+    text-align: center;    
+}
+
 figcaption {
     font-weight: 100;
     font-size: 1.2rem;


### PR DESCRIPTION
This PR adds an image component to replace the current inline HTML. This component supports captions and also makes images clickable (opening into a fresh tab).

Here's a page that uses this component: https://deploy-preview-35--buf.netlify.app/bsr/documentation.