### PR TITLE
Update plugin references

### DIFF
--- a/docs/configuration/v1/buf-gen-yaml.md
+++ b/docs/configuration/v1/buf-gen-yaml.md
@@ -27,7 +27,7 @@ plugins:
   - name: go
     out: gen/proto/go
     opt: paths=source_relative
-  - remote: buf.build/library/plugins/go-grpc:v1.1.0-2
+  - remote: buf.build/grpc/plugins/go:v1.2.0-1
     out: gen/proto/go
     opt:
       - paths=source_relative
@@ -57,8 +57,8 @@ executed by `buf`. This can be overridden with the [path](#path) option shown be
 
 In the case of `<remote>`, this allows you to run `buf generate` with a remote plugin, using the fully-qualified
 path to the remote plugin defined via the BSR, `<remote>/<owner>/plugins/<plugin-name>:<plugin-version>`. In the `buf.gen.yaml`
-example shown above, the `go-grpc` plugin managed by `buf.build/library` is being used as a part of the generation,
-and does not require a local installation of the `go-grpc` plugin. If no version is specified, the generation will default
+example shown above, the `go` plugin managed by `buf.build/grpc` is being used as a part of the generation,
+and does not require a local installation of the `go` plugin. If no version is specified, the generation will default
 to using the latest version available for the requested remote plugin.
 
 #### `out`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ Given a module, such as `buf.build/acme/weather`, you can consume generated code
 All via a `go` command that results in a Go module:
 
 ```sh
-$ go get go.buf.build/library/go-grpc/acme/weather
+$ go get go.buf.build/grpc/go/acme/weather
 ```
 
 Similar mechanisms will exist for other languages, such as:

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -47,7 +47,7 @@ generate *with*:
 go.buf.build/TEMPLATE_OWNER/TEMPLATE_NAME/MODULE_OWNER/MODULE_NAME
 ```
 
-With module `buf.build/$BUF_USER/petapis` and template `buf.build/grpc/template/go`, the result
+With module `buf.build/$BUF_USER/petapis` and template `buf.build/grpc/templates/go`, the result
 becomes:
 
 ```

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -33,7 +33,7 @@ client/main.go:10:2: no required module provides package github.com/bufbuild/buf
 ## 16.2 Depend on `go.buf.build` {#depend-on-gobufbuild}
 
 We can depend on the same Go/gRPC client and server stubs by adapting our import paths
-to use [https://buf.build/library/templates/go-grpc](https://buf.build/library/templates/go-grpc),
+to use [https://buf.build/grpc/templates/go](https://buf.build/grpc/templates/go),
 which is one of the BSR's [hosted templates](../bsr/remote-generation/overview.md#hosted-templates).
 
 In short, the `go-grpc` template acts exactly like the local `buf.gen.yaml` template we just removed,
@@ -47,7 +47,7 @@ generate *with*:
 go.buf.build/TEMPLATE_OWNER/TEMPLATE_NAME/MODULE_OWNER/MODULE_NAME
 ```
 
-With module `buf.build/$BUF_USER/petapis` and template `buf.build/library/template/go-grpc`, the result
+With module `buf.build/$BUF_USER/petapis` and template `buf.build/grpc/template/go`, the result
 becomes:
 
 ```


### PR DESCRIPTION
We should be pointing to the plugin https://buf.build/grpc/plugins/go instead of https://buf.build/library/plugins/go-grpc,  
and to the template https://buf.build/grpc/templates/go instead of https://buf.build/library/template/go-grpc.
