### PR TITLE
Fix label name error

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,7 +106,7 @@ module.exports = {
           label: 'GitHub',
           position: 'right',
           bufAppearance: 'github',
-          starGazers: 3511,
+          stargazers: 3511,
         },
       ],
     },

--- a/src/theme/NavbarItem/DefaultNavbarItem.tsx
+++ b/src/theme/NavbarItem/DefaultNavbarItem.tsx
@@ -17,9 +17,13 @@ import OriginalNavbarItem from '@theme-original/NavbarItem/DefaultNavbarItem';
 
 import styles from './DefaultNavbarItem.module.css';
 
+interface NavbarProps extends Props {
+    stargazers?: number;
+}
+
 // We are handling different "appearances" here. They mostly just style the nav bar item, but
 // "github" also fetches the stargazer count for the link URL and sets the result as a link label.
-function DefaultNavbarItem(props: Props): JSX.Element {
+function DefaultNavbarItem(props: NavbarProps): JSX.Element {
     let bufAppearance;
     [bufAppearance, props] = extractBufAppearance(props);
     let classNames: string[] = [styles.hideExternalLinkIcon];
@@ -50,7 +54,7 @@ function DefaultNavbarItem(props: Props): JSX.Element {
     const label = typeof props.label === "string" ? props.label : "GitHub";
 
     if (bufAppearance === "github") {
-        return <OriginalNavbarItem className={classNames.join(" ")} {...props} label={props.starGazers} />;
+        return <OriginalNavbarItem className={classNames.join(" ")} {...props} label={props.stargazers} />;
     }
 
     return <OriginalNavbarItem className={classNames.join(" ")} {...props} />;


### PR DESCRIPTION
I'm getting strange error in the console (pasted below). Apparently label names are applied as DOM element props. This small change seems to fix it.

```
Warning: React does not recognize the `starGazers` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `stargazers` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
a
Link@webpack-internal:///./node_modules/@docusaurus/core/lib/client/exports/Link.js:24:73
NavLink@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/DefaultNavbarItem.js:19:75
NavItemDesktop@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/DefaultNavbarItem.js:21:1300
DefaultNavbarItem@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/DefaultNavbarItem.js:22:2405
DefaultNavbarItem@webpack-internal:///./src/theme/NavbarItem/DefaultNavbarItem.tsx:23:75
NavbarItem@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/NavbarItem/index.js:19:363
div
div
nav
Navbar@webpack-internal:///./src/theme/Navbar/index.tsx:34:423
DocsPreferredVersionContextProviderUnsafe@webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/docsPreferredVersion/DocsPreferredVersionProvider.js:26:875
DocsPreferredVersionContextProvider@webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/docsPreferredVersion/DocsPreferredVersionProvider.js:26:488
UserPreferencesProvider@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/UserPreferencesProvider/index.js:13:157
AnnouncementBarProvider@webpack-internal:///./node_modules/@docusaurus/theme-common/lib/utils/announcementBarUtils.js:21:483
ThemeProvider@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/ThemeProvider/index.js:13:142
LayoutProviders@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/LayoutProviders/index.js:14:28
Layout@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/Layout/index.js:21:83
DocPageContent@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/DocPage/index.js:27:275
DocPage@webpack-internal:///./node_modules/@docusaurus/theme-classic/lib-next/theme/DocPage/index.js:29:2107
LoadableComponent@webpack-internal:///./node_modules/@docusaurus/react-loadable/lib/index.js:1:2843
Route@webpack-internal:///./node_modules/react-router/esm/react-router.js:464:29
Switch@webpack-internal:///./node_modules/react-router/esm/react-router.js:670:29
Route@webpack-internal:///./node_modules/react-router/esm/react-router.js:464:29
PendingNavigation@webpack-internal:///./node_modules/@docusaurus/core/lib/client/PendingNavigation.js:18:180
C@webpack-internal:///./node_modules/react-router/esm/react-router.js:725:31
Root@webpack-internal:///./node_modules/@docusaurus/core/lib/client/theme-fallback/Root/index.js:18:14
App@webpack-internal:///./node_modules/@docusaurus/core/lib/client/App.js:23:94
Router@webpack-internal:///./node_modules/react-router/esm/react-router.js:93:30
BrowserRouter@webpack-internal:///./node_modules/react-router-dom/esm/react-router-dom.js:59:35
```