### PR TITLE
Standardize on sh highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ https://docs.buf.build.
 
 To get started, make sure you have [Node] installed:
 
-```terminal
+```sh
 brew install node
 make install
 ```
 
 To run a local dev server, run:
 
-```terminal
+```sh
 make
 ```
 
 or
 
-```terminal
+```sh
 make run
 ```
 
@@ -30,7 +30,7 @@ having to restart the server.
 
 To view the fully built product, you can run:
 
-```terminal
+```sh
 make serve
 ```
 
@@ -165,7 +165,7 @@ The Buf documentation uses the [Vale] linter for its prose sources. The current 
 
 To lint the docs, install Vale and run:
 
-```terminal
+```sh
 vale docs
 
 # Alternatively:

--- a/docs/best-practices/module-development.md
+++ b/docs/best-practices/module-development.md
@@ -24,7 +24,7 @@ it unique across other module dependencies.
 <tbody>
 <tr><td>
 
-```
+```sh
 proto/
 ├── buf.lock
 ├── buf.yaml
@@ -33,7 +33,7 @@ proto/
 
 </td><td>
 
-```
+```sh
 proto/
 ├── acme
 │   └── pkg
@@ -94,7 +94,7 @@ versioned filepath, such as `acme/pkg/v2/pkg.proto`.
 
 This looks like the following:
 
-```
+```sh
 proto/
 ├── acme
 │   └── pkg

--- a/docs/bsr/authentication.md
+++ b/docs/bsr/authentication.md
@@ -41,7 +41,7 @@ The `buf` CLI reads its authentication credentials from your
 [.netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
 file. There is a `buf` command that manages the `.netrc` file for you, run the following command:
 
-```terminal
+```sh
 $ buf registry login
 ```
 
@@ -55,7 +55,7 @@ machine buf.build
 
 You can logout at any time with the following command:
 
-```terminal
+```sh
 $ buf registry logout
 ```
 
@@ -76,7 +76,7 @@ Access the secret token as specified by your CI provider and make it available a
 
 If this is not possible, you can also login via the CLI (assuming `BUF_API_TOKEN` and `BUF_USER` are set):
 
-```terminal
+```sh
 $ echo ${BUF_API_TOKEN} | buf registry login --username ${BUF_USER} --token-stdin
 ```
 

--- a/docs/bsr/overview.md
+++ b/docs/bsr/overview.md
@@ -71,7 +71,7 @@ deps:
 
 Once a dependency is added to the configuration file, you need to run:
 
-```terminal
+```sh
 $ buf mod update
 ```
 
@@ -129,7 +129,7 @@ Instead, users bring their own plugins and generate code from a single source of
 
 In your [`buf.gen.yaml`](../configuration/v1/buf-gen-yaml.md) define plugins and their respective options, and then generate your code with the `buf` CLI by referencing a BSR module:
 
-```terminal
+```sh
 $ buf generate buf.build/acme/weather
 ```
 

--- a/docs/bsr/remote-generation/concepts.md
+++ b/docs/bsr/remote-generation/concepts.md
@@ -17,19 +17,19 @@ Plugin version executables are managed as Docker images. The Docker image is exp
 
 A plugin version is created by pushing a tagged Docker image to the plugins Docker registry repository. For example, assuming the relevant `Dockerfile` and context was in the current directory, to push a new version `v1.1.0` of the plugin `protoc-gen-myplugin` owned by the user `myuser`, the user would run
 
-```terminal
+```sh
 $ docker build -t plugins.buf.build/myuser/protoc-gen-myplugin:v1.1.0 .
 ```
 
 followed by
 
-```terminal
+```sh
 $ docker push plugins.buf.build/myuser/protoc-gen-myplugin:v1.1.0
 ```
 
 Pushing plugins to the BSR requires authenticating your Docker CLI using a **token**:
 
-```terminal
+```sh
 $ docker login -u myuser --password-stdin plugins.buf.build
 ```
 

--- a/docs/bsr/remote-generation/consuming-generated-code.md
+++ b/docs/bsr/remote-generation/consuming-generated-code.md
@@ -89,7 +89,7 @@ To generate Go code from private modules you'll need to make sure the Go tooling
 The `go` tool uses [`.netrc` credentials](https://golang.org/ref/mod#private-module-proxy-auth) if available and you can use `buf registry login` to add this to your `.netrc` file.
 You can obtain an API token (password) from the [Settings Page](https://buf.build/settings/user).
 
-```terminal
+```sh
 $ buf registry login
 ```
 
@@ -108,7 +108,7 @@ The `GOPRIVATE` environment variable controls which modules the `go` command con
 
 Set this environment variable.
 
-```terminal
+```sh
 $ export GOPRIVATE=go.buf.build
 ```
 

--- a/docs/bsr/remote-generation/hosted-plugins.md
+++ b/docs/bsr/remote-generation/hosted-plugins.md
@@ -175,7 +175,7 @@ Note, we're using the `remote` key instead of `name` to reference a remote plugi
 
 It is possible to reference both local and remote plugins within a single template file. The `buf generate` command issues an RPC to the BSR to execute the remote plugins against the given input. Once execution is finished the output is written out to disk.
 
-```terminal
+```sh
 $ buf generate buf.build/demolab/theweather
 ```
 
@@ -193,7 +193,7 @@ What you should end up with is the following structure:
   ]}>
   <TabItem value="go">
 
-```bash
+```sh
 .
 ├── buf.gen.yaml
 └── gen
@@ -207,7 +207,7 @@ What you should end up with is the following structure:
   </TabItem>
   <TabItem value="javascript">
 
-```bash
+```sh
 .
 ├── buf.gen.yaml
 └── gen
@@ -221,7 +221,7 @@ What you should end up with is the following structure:
   </TabItem>
   <TabItem value="python">
 
-```bash
+```sh
 .
 ├── buf.gen.yaml
 └── gen
@@ -235,7 +235,7 @@ What you should end up with is the following structure:
   </TabItem>
   <TabItem value="ruby">
 
-```bash
+```sh
 .
 ├── buf.gen.yaml
 └── gen
@@ -249,7 +249,7 @@ What you should end up with is the following structure:
   </TabItem>
   <TabItem value="java">
 
-```bash
+```sh
 .
 ├── buf.gen.yaml
 └── gen

--- a/docs/bsr/remote-generation/plugin-example.md
+++ b/docs/bsr/remote-generation/plugin-example.md
@@ -15,7 +15,7 @@ The `protoc-gen-twirp` source code can be found [here](https://github.com/twitch
 
 To push plugins to the BSR, you will need to authenticate to the plugin Docker registry using `docker login`. The username doesn't matter, but has to be provided. Obtain an API token (password) from the [Settings Page](https://buf.build/settings/user) and run the following command:
 
-```terminal
+```sh
 $ docker login -u myuser plugins.buf.build
 ---
 password:
@@ -37,7 +37,7 @@ However, for this example we'll use the `buf` CLI.
 
 Create the plugin with `buf` command:
 
-```terminal
+```sh
 $ buf beta registry plugin create \
     buf.build/demolab/plugins/twirp --visibility public 
 ---
@@ -102,7 +102,7 @@ Once we prepared the Dockerfile, the next step is to build and tag an image.
 
 We'll do so locally by running the following command:
 
-```terminal
+```sh
 $ docker build -f Dockerfile.twirp -t plugins.buf.build/demolab/twirp:v8.1.0-1 .
 ```
 
@@ -113,7 +113,7 @@ package versioning systems.
 
 Lastly, publish the containerized `protoc`-based plugin to the BSR. Make sure you have [authenticated](#1-docker-registry-authentication) your docker client in step 1.
 
-```terminal
+```sh
 $ docker push plugins.buf.build/demolab/twirp:v8.1.0-1
 ---
 The push refers to repository [plugins.buf.build/demolab/twirp]

--- a/docs/bsr/remote-generation/template-example.md
+++ b/docs/bsr/remote-generation/template-example.md
@@ -33,7 +33,7 @@ Similar to `protoc` command-line flags, you will capture options as part of your
 
 For Go-based templates include `paths=source_relative` for all plugin options.
 
-```terminal
+```sh
 $ buf beta registry template create buf.build/demolab/templates/twirp-go \
 	--visibility public \
 	--config '{"version":"v1","plugins":[{"owner":"library","name":"go","opt":["paths=source_relative"]},{"owner":"demolab","name":"twirp","opt":["paths=source_relative"]}]}'
@@ -44,7 +44,7 @@ demolab  twirp-go
 
 ### 2. Set plugin versions
 
-```terminal
+```sh
 $ buf beta registry template version create buf.build/demolab/templates/twirp-go \
 	--name v1 \
 	--config '{"version":"v1","plugin_versions":[{"owner":"library","name":"go","version":"v1.27.1-1"},{"owner":"demolab","name":"twirp","version":"v8.1.0-1"}]}'
@@ -91,7 +91,7 @@ The BSR will remotely generate Go code for this module using the `twirp-go` temp
 
 Code generation takes place on the fly when a user fetches code for the first time. You may notice a delay for the initial run, but the generated code will get cached in the BSR Go module proxy and subsequent requests are much quicker.
 
-```terminal
+```sh
 $ go get go.buf.build/demolab/twirp-go/demolab/theweather
 $ go mod tidy
 ```
@@ -107,7 +107,7 @@ require (
 
 As you iterate on a Protobuf API and push to the BSR, you will likely need to generate and update code. To do so, update the go.mod file by setting the desired version explicitly and then run `go mod tidy`. This will once again remote generate code and cache the result.
 
-```bash {4}
+```sh {4}
 require (
 	github.com/twitchtv/twirp v8.1.0+incompatible // indirect
 - 	go.buf.build/demolab/twirp-go/demolab/theweather v1.1.1
@@ -150,7 +150,7 @@ The really neat feature of BSR Remote Generation is consumers of the Twirp API g
 
 Here is a fully working Go client SDK for the above Twirp server. Again, we're importing remote generated code from the BSR Go module proxy.
 
-```terminal title="cmd/consumer/main.go" {9}
+```sh title="cmd/consumer/main.go" {9}
 package main
 
 import (

--- a/docs/bsr/usage.md
+++ b/docs/bsr/usage.md
@@ -7,7 +7,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 To execute `buf` commands below make sure you are [authenticated](../bsr/authentication.md). Obtain a token from the BSR and run:
 
-```terminal
+```sh
 $ buf registry login
 ```
 
@@ -28,7 +28,7 @@ Through the **UI** log in at [https://buf.build/login](https://buf.build/login) 
 
 Alternatively, use the **CLI** run the following command:
 
-```terminal
+```sh
 $ buf beta registry repository create <MODULE_NAME> --visibility [public,private]
 ```
 
@@ -48,7 +48,7 @@ name: buf.build/acme/weather
 
 Push your module to the BSR by running the following command:
 
-```terminal
+```sh
 $ buf push
 ```
 
@@ -98,7 +98,7 @@ breaking:
 
 After adding dependencies in `buf.yaml` run the following command:
 
-```terminal
+```sh
 $ buf mod update
 ```
 
@@ -144,7 +144,7 @@ The `buf` CLI infers the `protoc-gen-{name}` prefix for each plugin specified by
 
 Once you set up a `buf.gen.yaml` file, run the following command and specify a module hosted on the BSR. That's right, you can reference a hosted BSR module without having the Protobuf files locally!
 
-```terminal
+```sh
 $ buf generate <MODULE_NAME>
 ```
 
@@ -163,12 +163,12 @@ deprecated repository.
 
 You can deprecate a repository with
 
-```terminal
+```sh
 $ buf beta registry repository deprecate <buf.build/owner/repository> [--message <deprecation message>]
 ```
 
 Undeprecate a deprecated repository with
 
-```terminal
+```sh
 $ buf beta registry repository undeprecate <buf.build/owner/repository>
 ```

--- a/docs/build/usage.md
+++ b/docs/build/usage.md
@@ -243,8 +243,9 @@ $ buf build -o -#format=json
 When combined with [jq](https://stedolan.github.io/jq), `buf build` also allows for introspection. For example,
 to see a list of all packages, you can run the following command:
 
-```
+```sh
 $ buf build -o -#format=json | jq '.file[] | .package' | sort | uniq | head
+---
 "google.actions.type"
 "google.ads.admob.v1"
 "google.ads.googleads.v1.common"

--- a/docs/ci-cd/setup.md
+++ b/docs/ci-cd/setup.md
@@ -41,7 +41,7 @@ import TabItem from '@theme/TabItem';
   ]}>
 <TabItem value="download">
 
-```bash title="install.sh"
+```sh title="install.sh"
 #!/bin/bash
 
 PROJECT=<your-project-name>
@@ -65,7 +65,7 @@ for the given `BUF_VERSION` and operating system. The binary is then given execu
 If you intend on building `buf` from source, this assumes that you have the Go toolchain available in your CI/CD.
 If not, please refer to the [Go Documentation](https://golang.org/) for more details.
 
-```bash title="install.sh"
+```sh title="install.sh"
 #!/bin/bash
 
 BUF_TMP=$(mktemp -d)
@@ -135,7 +135,7 @@ You can then access the token in your job using an environment variable, which a
 `.netrc` file for your job during setup. Here's an example assuming you've stored your token as `BUF_API_TOKEN`
 and your username as `BUF_USER`:
 
-```terminal
+```sh
 $ echo ${BUF_API_TOKEN} | buf registry login --username ${BUF_USER} --token-stdin
 ```
 

--- a/docs/configuration/v1/buf-gen-yaml.md
+++ b/docs/configuration/v1/buf-gen-yaml.md
@@ -146,7 +146,7 @@ strategy is used by default if omitted.
 This will result in `buf` making a single plugin invocation with all input files. This is roughly equivalent to
 the following:
 
-```
+```sh
 $ protoc -I . $(find . -name '*.proto')
 ```
 

--- a/docs/editor-integration.mdx
+++ b/docs/editor-integration.mdx
@@ -105,7 +105,7 @@ path/to/file.proto(1,10) : error COMPILE : syntax value must be "proto2" or "pro
 </TabItem>
 <TabItem value="json">
 
-```
+```json
 {"path":"path/to/file.proto","start_line":1,"start_column":10,"end_line":1,"end_column":10,"type":"COMPILE","message":"syntax value must be \"proto2\" or \"proto3\""}
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ In January 2021 (v0.34.0), `protoc-gen-buf-check-breaking` and `protoc-gen-buf-c
 
 The only migration necessary is to change your installation and invocation from `protoc-gen-buf-check-breaking` to `protoc-gen-buf-breaking` and `protoc-gen-buf-check-lint` to `protoc-gen-buf-lint`. These can be installed in the exact same manner, whether from GitHub Releases, Homebrew, AUR, or direct Go installation:
 
-```
+```sh
 # instead of go get github.com/bufbuild/buf/cmd/protoc-gen-buf-check-breaking
 go get github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking
 # instead of curl -sSL https://github.com/bufbuild/buf/releases/download/v0.57.0/protoc-gen-buf-check-breaking-Linux-x86_64

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -132,7 +132,7 @@ VERSION="1.0.0-rc12" && \
 The binaries can be installed from source if `go` is installed, however we recommend using one of
 the release assets instead.
 
-```
+```sh
 # Substitute GOBIN for your bin directory
 # Leave unset to default to $GOPATH/bin
 GO111MODULE=on GOBIN=/usr/local/bin go get \

--- a/docs/reference/images.md
+++ b/docs/reference/images.md
@@ -246,7 +246,7 @@ $ buf build -o image.json.zst
 
 The special value `-` is used to denote stdout. You can manually set the format. For example:
 
-```
+```sh
 $ buf build -o -#format=json
 ```
 
@@ -270,7 +270,7 @@ $ buf build -o -#format=json | jq '.file[] | .package' | sort | uniq | head
 Images always include the ImageFileExtension field. However, if you want a pure FileDescriptorSet
 without this field set, to mimic `protoc` entirely:
 
-```
+```sh
 $ buf build -o image.bin --as-file-descriptor-set
 ```
 

--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -23,7 +23,7 @@ Start by removing the `google/type/datetime.proto` file from your module altoget
 From within the `petapis` directory, run this command to remove _all_ of the local `google`
 dependencies:
 
-```terminal
+```sh
 $ rm -rf google
 ```
 
@@ -43,7 +43,7 @@ Now remove the `google/type/datetime.proto` reference from your[`buf.yaml`](../c
 
 If you try to build the module in its current state, you will notice an error:
 
-```terminal
+```sh
 $ buf build
 ---
 pet/v1/pet.proto:7:8:google/type/datetime.proto: does not exist
@@ -69,7 +69,7 @@ the `buf.build/googleapis/googleapis` module, so you can configure it like this:
 
 Now, if you try to build the module again, you'll notice this:
 
-```terminal
+```sh
 $ buf build
 ---
 WARN	Specified deps are not covered in your buf.lock, run "buf mod update":
@@ -83,7 +83,7 @@ module, representing a single reproducible build of your module's dependencies. 
 `buf.lock` file yet because you haven't specified any external dependencies, but you can create one with
 the command that `buf` recommended above:
 
-```terminal
+```sh
 $ buf mod update
 ```
 
@@ -103,7 +103,7 @@ deps:
 
 Now, if you try to build the module again, you'll notice that it's successful:
 
-```terminal
+```sh
 $ buf build
 ---
 buf: downloading buf.build/googleapis/googleapis:1c473ad9220a49bca9320f4cc690eba5
@@ -163,7 +163,7 @@ With that said, restore the `buf.yaml` file to its previous state before you con
 Now that you've updated your module to depend on `buf.build/googleapis/googleapis` instead of vendoring
 the `google/type/datetime.proto` yourself, you can push the module to the BSR:
 
-```terminal
+```sh
 $ buf push
 ---
 b2917eb692064beb92ad1e38dba6c25e

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -10,7 +10,7 @@ Clone the [`bufbuild/buf-tour`](https://github.com/bufbuild/buf-tour.git) reposi
 from GitHub and navigate to the `petapis` directory, which contains the pet store's
 `.proto` files:
 
-```terminal
+```sh
 $ git clone https://github.com/bufbuild/buf-tour.git
 $ cd buf-tour/start/petapis
 ```
@@ -20,7 +20,7 @@ $ cd buf-tour/start/petapis
 `buf` is configured with a [`buf.yaml`](../configuration/v1/buf-yaml.md) file, which is easily
 created with the following command:
 
-```terminal
+```sh
 $ buf config init
 ```
 
@@ -50,7 +50,7 @@ are stitched together with a [`buf.work.yaml`](../configuration/v1/buf-work-yaml
 We'll cover workspaces when working with multiple roots later in the tour, but to illustrate how all these pieces
 fit together here's a quick example using `protoc` and its equivalent in `buf`:
 
-```terminal
+```sh
 $ protoc \
     -I proto \
     -I vendor/protoc-gen-validate \
@@ -90,7 +90,7 @@ For now, we'll stick to the `buf.yaml` we created above.
 
 Before we continue, let's verify that everything is set up properly:
 
-```terminal
+```sh
 $ buf build
 ```
 
@@ -102,7 +102,7 @@ Plus, you can see some interesting details about the compiled artifact with a fe
 [jq](https://stedolan.github.io/jq). This command displays a list of the Protobuf packages used
 in this project:
 
-```terminal
+```sh
 $ buf build --exclude-source-info -o -#format=json | jq '.file[] | .package'
 ---
 "google.protobuf"

--- a/docs/tour/detect-breaking-changes.md
+++ b/docs/tour/detect-breaking-changes.md
@@ -49,7 +49,7 @@ For example, change the type of the `Pet.pet_type` field from `PetType` to `stri
 Now, you can verify that this is a breaking change against the local `main` branch. You'll also
 notice errors related to the changes you made in the [previous step](lint-your-api.md):
 
-```terminal
+```sh
 $ buf breaking --against ../../.git#branch=main,subdir=start/petapis
 ---
 pet/v1/pet.proto:1:1:Previously present service "PetStore" was deleted from file.
@@ -60,7 +60,7 @@ pet/v1/pet.proto:44:10:Field "1" on message "DeletePetRequest" changed name from
 
 Similarly, you can target a [`zip`][zip] archive from the remote repository:
 
-```terminal
+```sh
 $ buf breaking \
   --against "https://github.com/bufbuild/buf-tour/archive/main.zip#strip_components=1,subdir=start/petapis" \
   --config buf.yaml
@@ -95,7 +95,7 @@ fun example, let's build an image out of our current state, write it to stdout, 
 the input from stdin. This should _always_ pass, as it compares the current state to the current
 state:
 
-```terminal
+```sh
 $ buf build -o - | buf breaking --against -
 ```
 

--- a/docs/tour/generate-code.md
+++ b/docs/tour/generate-code.md
@@ -8,7 +8,7 @@ with any existing usage of `protoc`.
 
 Move back to the `start` directory with this command:
 
-```terminal
+```sh
 $ cd ..
 ```
 
@@ -57,7 +57,7 @@ C++ and Java code associated with the `PetStoreService` API.
 
 Run this command, targeting the input defined in the `petapis` directory:
 
-```terminal
+```sh
 $ buf generate petapis
 ```
 
@@ -134,7 +134,7 @@ for C++ and Java. You can disable [`cc_enable_arenas`][cc_enable_arenas] and ena
 
 If you regenerate the C++ and Java code, you'll notice that the generated content has changed:
 
-```terminal
+```sh
 $ rm -rf gen
 $ buf generate petapis
 ```
@@ -207,7 +207,7 @@ For now, restore your `buf.gen.yaml` configuration before you continue:
 
 Then regenerate the original code:
 
-```terminal
+```sh
 $ rm -rf gen
 $ buf generate petapis
 ```

--- a/docs/tour/generate-go-code.md
+++ b/docs/tour/generate-go-code.md
@@ -11,7 +11,7 @@ and added a dependency on the `buf.build/googleapis/googleapis` module. Next, yo
 Before you continue, move to the `start` directory again. If you're coming from the [previous
 step](add-a-dependency), you can run this command:
 
-```terminal
+```sh
 $ cd ..
 ```
 
@@ -19,7 +19,7 @@ You should also reset the `gen` directory so that you can generate everything fr
 This is especially relevant since you removed the `google/type/datetime.proto` definition from
 the module itself.
 
-```terminal
+```sh
 $ rm -rf gen
 ```
 
@@ -47,14 +47,14 @@ that's OK! We'll cover everything you need to know here.
 You'll be using the `protoc-gen-go` and `protoc-gen-go-grpc` plugins to generate code with `buf generate`,
 so you'll need to install them:
 
-```terminal
+```sh
 $ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 ```
 
 You also need to update your `PATH` so that `buf` can find the plugins:
 
-```terminal
+```sh
 $ export PATH="$PATH:$(go env GOPATH)/bin"
 ```
 
@@ -95,7 +95,7 @@ required to implement the `PetStoreService` API with Go.
 
 Run this command, which targets the version of the module your pushed to the BSR earlier:
 
-```terminal
+```sh
 $ buf generate buf.build/$BUF_USER/petapis
 ```
 

--- a/docs/tour/implement-grpc-endpoints.md
+++ b/docs/tour/implement-grpc-endpoints.md
@@ -10,7 +10,7 @@ on the command line.
 
 Before you write Go code, initialize a `go.mod` file with the `go mod init` command:
 
-```terminal
+```sh
 $ go mod init github.com/bufbuild/buf-tour/petstore
 ```
 
@@ -21,7 +21,7 @@ code's Go dependencies.
 
 You can start implementing a server by creating a `server/main.go` file:
 
-```terminal
+```sh
 $ mkdir server
 $ touch server/main.go
 ```
@@ -85,7 +85,7 @@ func (s *petStoreServiceServer) PutPet(ctx context.Context, req *petv1.PutPetReq
 
 You can start implementing a client by creating a `client/main.go` file:
 
-```terminal
+```sh
 $ mkdir client
 $ touch client/main.go
 ```
@@ -137,7 +137,7 @@ func run() error {
 Now that you have code for both a client and a server, run this command to resolve
 some of the dependencies you need for the generated code:
 
-```terminal
+```sh
 $ go mod tidy
 ```
 
@@ -162,7 +162,7 @@ call the `PutPet` endpoint from the client.
 
 First, run the server:
 
-```terminal
+```sh
 $ go run server/main.go
 ---
 ... Listening on 127.0.0.1:8080
@@ -170,7 +170,7 @@ $ go run server/main.go
 
 In a separate terminal, run the client and you should see a success message:
 
-```terminal
+```sh
 $ go run client/main.go
 ---
 ... Connected to 127.0.0.1:8080
@@ -179,7 +179,7 @@ $ go run client/main.go
 
 You'll also notice this in the server logs (in the other terminal running the server):
 
-```terminal
+```sh
 $ go run server/main.go
 ---
 ... Listening on 127.0.0.1:8080

--- a/docs/tour/introduction.md
+++ b/docs/tour/introduction.md
@@ -34,7 +34,7 @@ $ buf protoc --help
 First, clone the Git repository that contains the starter code for the `PetStore` service.
 From the development directory of your choice, run the following command:
 
-```terminal
+```sh
 $ git clone https://github.com/bufbuild/buf-tour
 ```
 
@@ -87,6 +87,6 @@ buf-tour/
 
 To begin, move into the `start` directory and continue to the next step:
 
-```terminal
+```sh
 $ cd buf-tour/start
 ```

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -5,7 +5,7 @@ title: 3 Lint Your API
 
 You can run all of the configured lint rules with the following:
 
-```terminal
+```sh
 $ buf lint
 ---
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
@@ -29,7 +29,7 @@ breaking:
 
 You can also output lint failures as JSON:
 
-```terminal
+```sh
 $ buf lint --error-format=json
 ---
 {"path":"google/type/datetime.proto","start_line":17,"start_column":1,"end_line":17,"end_column":21,"type":"PACKAGE_VERSION_SUFFIX","message":"Package name \"google.type\" should be suffixed with a correctly formed version, such as \"google.type.v1\"."}
@@ -64,7 +64,7 @@ To make `buf` happy, you can exclude these rules from the `DEFAULT` category by 
 
 Now if you run `buf lint` again, you'll notice that it's successful (exit code 0 and no output):
 
-```terminal
+```sh
 $ buf lint
 ```
 
@@ -119,7 +119,7 @@ fix the failures with the following updates:
 
 You can verify that two of the failures are resolved by linting again and seeing only one remaining error:
 
-```terminal
+```sh
 $ buf lint
 ---
 google/type/datetime.proto:17:1:Package name "google.type" should be suffixed with a correctly formed version, such as "google.type.v1".
@@ -148,7 +148,7 @@ Alternatively, you can specify exactly which rules to ignore using the [`ignore_
 parameter. You can output failures in a format that you can then copy into your `buf.yaml` file. This allows you to ignore
 all existing lint errors and correct them over time:
 
-```terminal
+```sh
 $ buf lint --error-format=config-ignore-yaml
 ---
 version: v1
@@ -165,7 +165,7 @@ In this case, you don't own the `google/type/datetime.proto` file, so it's best 
 The `buf lint` command also works with remote inputs, using the local `buf.yaml` configuration. For example, you can see all
 the original lint failures if you reference a `tar.gz` archive from the `main` branch:
 
-```terminal
+```sh
 $ buf lint "https://github.com/bufbuild/buf-tour/archive/main.tar.gz#strip_components=1,subdir=start/petapis" --config buf.yaml
 ---
 start/petapis/pet/v1/pet.proto:44:10:Field name "petID" should be lower_snake_case, such as "pet_id".

--- a/docs/tour/list-all-protobuf-files.md
+++ b/docs/tour/list-all-protobuf-files.md
@@ -6,7 +6,7 @@ title: 2 List All Protobuf Files
 You can list all of the `.proto` files managed by `buf` per the
 [build configuration](../configuration/v1/buf-yaml#build):
 
-```terminal
+```sh
 $ buf ls-files
 ---
 google/type/datetime.proto
@@ -21,7 +21,7 @@ necessary nor recommended.
 
 The `ls-files` command also works with remote inputs, such as the following:
 
-```terminal
+```sh
 $ buf ls-files git://github.com/bufbuild/buf-tour.git#branch=main,subdir=start/petapis
 ---
 start/petapis/google/type/datetime.proto

--- a/docs/tour/login-to-the-bsr.md
+++ b/docs/tour/login-to-the-bsr.md
@@ -18,7 +18,7 @@ Throughout this tour, you'll see references to the `BUF_USER` environment variab
 newly created BSR username. Once you have completed registration, export this value
 so that you can copy and paste commands.
 
-```terminal
+```sh
 # Note this is just for the tour!
 $ export BUF_USER=<YOUR_BUF_USER>
 ```
@@ -39,7 +39,7 @@ Click **Create** and copy the token to your clipboard.
 
 All you need to log in is the API token created above. Run this command to do so:
 
-```terminal
+```sh
 $ buf registry login
 ```
 
@@ -60,7 +60,7 @@ machine go.buf.build
 
 You can log out at any time using this command:
 
-```terminal
+```sh
 $ buf registry logout
 ---
 All existing BSR credentials removed from $HOME/.netrc.

--- a/docs/tour/push-a-module.md
+++ b/docs/tour/push-a-module.md
@@ -45,7 +45,7 @@ Name | Remote | Owner | Repository
 
 Create a new `petapis` repository for your module with the following command:
 
-```terminal
+```sh
 $ buf beta registry repository create buf.build/$BUF_USER/petapis --visibility public
 ---
 Full name                    Created
@@ -56,7 +56,7 @@ buf.build/$BUF_USER/petapis  ...
 
 Move back into the `petapis` directory:
 
-```terminal
+```sh
 $ cd petapis
 ```
 
@@ -78,7 +78,7 @@ Update your `buf.yaml` so that its `name` matches the repository you just create
 Push the module to the `buf.build/$BUF_USER/petapis` repository with the following command (in the
 `petapis` directory containing your `buf.yaml`):
 
-```terminal
+```sh
 $ buf push
 ---
 19bcefa1a736428d9e64d21c9191b213

--- a/docs/tour/push-workspace-modules.md
+++ b/docs/tour/push-workspace-modules.md
@@ -14,7 +14,7 @@ You successfully generated Go/gRPC client and server stubs in a [previous
 step](/tour/generate-go-code.md), but if you try to push your `petapis` Protobuf module to the BSR
 you'll get this error:
 
-```terminal
+```sh
 $ cd petapis
 $ buf push
 ---
@@ -23,7 +23,7 @@ Failure: pet/v1/pet.proto:5:8:payment/v1alpha1/payment.proto: does not exist.
 
 This is a bit puzzling because you can successfully build the module locally:
 
-```
+```sh
 $ buf build
 ```
 
@@ -51,7 +51,7 @@ push a new version of that module. However, you just introduced the
 `buf.build/$BUF_USER/paymentapis` module, so you need to create the
 `buf.build/$BUF_USER/paymentapis` repository:
 
-```terminal
+```sh
 $ buf beta registry repository create buf.build/$BUF_USER/paymentapis --visibility public
 ---
 Full name                        Created
@@ -60,7 +60,7 @@ buf.build/$BUF_USER/paymentapis  ...
 
 Now that the repository exists, change into the `paymentapis` directory and push the module:
 
-```terminal
+```sh
 $ cd ../paymentapis
 $ buf push
 ---
@@ -72,7 +72,7 @@ $ buf push
 The `buf.build/$BUF_USER/paymentapis` repository now contains the same content you have locally, so
 you can add it as a dependency to the local `petapis` module:
 
-```terminal
+```sh
 $ cd ../petapis
 ```
 
@@ -91,7 +91,7 @@ $ cd ../petapis
 
 Update your dependencies with this command:
 
-```terminal
+```sh
 $ buf mod update
 ```
 
@@ -120,7 +120,7 @@ deps:
 
 You can now push the `petapis` module:
 
-```terminal
+```sh
 $ buf push
 ---
 dda6041ec265455d813f037c36c30349

--- a/docs/tour/use-a-workspace.md
+++ b/docs/tour/use-a-workspace.md
@@ -23,7 +23,7 @@ own `petapis`.
 You can enact a separation like this by creating a separate directory and initializing a Buf module
 there:
 
-```terminal
+```sh
 $ mkdir paymentapis
 $ cd paymentapis
 $ buf config init
@@ -56,7 +56,7 @@ You can also provide a `name` for the module:
 
 Now that the module is all set up, add an API:
 
-```terminal
+```sh
 $ mkdir -p payment/v1alpha1
 $ touch payment/v1alpha1/payment.proto
 ```
@@ -94,7 +94,7 @@ message Order {
 
 If you try to build the `paymentapis` module in its current state, you'll get an error:
 
-```terminal
+```sh
 $ buf build
 ---
 payment/v1alpha1/payment.proto:7:8:google/type/money.proto: does not exist
@@ -117,7 +117,7 @@ To fix this, add the `buf.build/googleapis/googleapis` dependency and resolve it
 
 Now update your dependencies and try building again:
 
-```terminal
+```sh
 $ buf mod update
 $ buf build
 ```
@@ -144,7 +144,7 @@ within the root of the `start` directory, the `buf.work.yaml` should be placed t
 configuration, you only need to specify the paths of the modules you want to include in the
 workspace. Here's what the config looks like for the `paymentapis` and `petapis` modules:
 
-```terminal
+```sh
 $ cd ..
 $ touch buf.work.yaml
 ```
@@ -158,7 +158,7 @@ directories:
 
 Your directory structure should now look like this:
 
-```terminal
+```sh
 start/
 ├── buf.gen.yaml
 ├── buf.work.yaml
@@ -226,7 +226,7 @@ Adapt the `PetStoreService` with the `PurhcasePet` endpoint like this:
 
 Verify that the `petapis` module builds with the latest import:
 
-```terminal
+```sh
 $ buf build petapis
 ```
 
@@ -241,7 +241,7 @@ the result:
    - petapis
 ```
 
-```terminal
+```sh
 $ buf build petapis
 petapis/pet/v1/pet.proto:7:8:payment/v1alpha1/payment.proto: does not exist
 ```
@@ -288,7 +288,7 @@ in the `buf.work.yaml` with a single command:
  }
 ```
 
-```terminal
+```sh
 $ buf lint
 paymentapis/payment/v1alpha1/payment.proto:20:10:Field name "orderID" should be lower_snake_case, such as "order_id".
 petapis/pet/v1/pet.proto:28:10:Field name "petID" should be lower_snake_case, such as "pet_id".

--- a/docs/tour/use-managed-mode.md
+++ b/docs/tour/use-managed-mode.md
@@ -53,7 +53,7 @@ With Managed Mode, you can remove the `go_package` option altogether, as in thes
 If you regenerate Go code stubs for the API changes you made in your local
 [workspace](/reference/workspaces.md), you'll notice this:
 
-```terminal
+```sh
 $ rm -rf gen
 $ buf generate
 ---
@@ -126,7 +126,7 @@ And the corresponding Buf configuration:
 
 If you regenerate the stubs now, you'll notice that it's successful:
 
-```terminal
+```sh
 $ rm -rf gen
 $ buf generate
 ```
@@ -195,14 +195,14 @@ With the `except` setting, the `go_package` option in all of the files provided 
 
 If you regenerate the stubs, you'll notice that it's successful:
 
-```terminal
+```sh
 $ rm -rf gen
 $ buf generate
 ```
 
 You can also verify that the generated code compiles with this command:
 
-```terminal
+```sh
 $ go build ./...
 ```
 

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -18,14 +18,14 @@ generation workflow to two steps:
 You won't need to generate any code locally at this stage, so you can remove the `buf.gen.yaml` as
 well as the generated code in the `gen` directory:
 
-```terminal
+```sh
 $ rm buf.gen.yaml
 $ rm -rf gen
 ```
 
 As expected, if you try to recompile your Go program, you'll notice a compilation error:
 
-```terminal
+```sh
 $ go build ./...
 ---
 client/main.go:10:2: no required module provides package github.com/bufbuild/buf-tour/petstore/gen/proto/go/pet/v1; to add it:
@@ -96,7 +96,7 @@ Update your import paths accordingly:
 Now if you run the command below, you'll notice that the remote-generated library is
 successfully resolved:
 
-```terminal
+```sh
 $ go mod tidy
 ---
 go: finding module for package go.buf.build/grpc/go/$BUF_USER/petapis/pet/v1
@@ -113,7 +113,7 @@ You can run the application again to verify that the remote-generated library wo
 
 First, start the server:
 
-```terminal
+```sh
 $ go run server/main.go
 ---
 ... Listening on 127.0.0.1:8080
@@ -121,7 +121,7 @@ $ go run server/main.go
 
 In a separate terminal, run the client and you'll see a successful `PutPet` operation:
 
-```terminal
+```sh
 $ go run client/main.go
 ---
 ... Connected to 127.0.0.1:8080
@@ -130,7 +130,7 @@ $ go run client/main.go
 
 You'll also notice this in the server logs (in the other terminal running the server):
 
-```terminal
+```sh
 $ go run server/main.go
 ---
 ... Listening on 127.0.0.1:8080
@@ -214,7 +214,7 @@ incrementing the final element in the synthetic version (described above).
 
 To demonstrate, make a simple change by adding a comment to the `PetStoreService`:
 
-```terminal
+```sh
 $ cd petapis
 ```
 
@@ -230,7 +230,7 @@ $ cd petapis
 
 Push those changes:
 
-```terminal
+```sh
 $ buf push
 ---
 8535a2784a3a48f6b72f2cb80eb49ac7
@@ -254,7 +254,7 @@ Now edit your `go.mod` to use the latest version (the 5th commit):
 If you run the command below, you'll notice that your `go.sum` is updated with
 the version specified in your `go.mod`:
 
-```terminal
+```sh
 $ go mod tidy
 ```
 

--- a/docs/tour/view-generated-documentation.md
+++ b/docs/tour/view-generated-documentation.md
@@ -24,7 +24,7 @@ currently supports all of the [CommonMark](https://commonmark.org) syntax.
 
 Let's start by adding a simple note like so:
 
-```terminal
+```sh
 $ touch buf.md
 ```
 
@@ -51,7 +51,7 @@ petapis/
 If you push your module to the BSR again, you'll notice a new commit and the documentation will have
 been updated to reflect the latest changes:
 
-```terminal
+```sh
 $ buf push
 4514ddced0584e73a100e82096c7958c
 ```


### PR DESCRIPTION
Just a small ergonomic thing. The minor benefit of using `sh` is that you get syntax highlighting in Markdown in most editors. Just saw multiple shells being used.

@mfridman If there was a specific reason for choosing `terminal`, let me know and I'm happy to update/revert.