### PR TITLE
Update browserslist DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ There are currently two checks in place:
 
 Linting is currently performed on an ad hoc basis.
 
+## Keeping the Browserslist up to date
+
+Periodically, mostly when prompted by log output from various systems, we should update the
+Browserslist "database" using this command:
+
+```terminal
+npx browserslist@latest --update-db
+```
+
+This is expected to update only the `package-lock.json` and no other files.
+
 [buf]: https://buf.build
 [node]: https://nodejs.org
 [vale]: https://docs.errata.ai

--- a/package-lock.json
+++ b/package-lock.json
@@ -4379,9 +4379,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001307",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
+      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -18855,9 +18855,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A=="
+      "version": "1.0.30001307",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
+      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng=="
     },
     "ccount": {
       "version": "1.1.0",


### PR DESCRIPTION
The reasoning behind this is explained [here](https://github.com/browserslist/browserslist#browsers-data-updating). Something we should periodically run as normal housekeeping. To confirm, this DB update is indeed only supposed to update lockfiles.