### PR TITLE
Remove tap mention in Homebrew installation instructions

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -20,12 +20,10 @@ import DownloadButton, {mac, linux, windows} from '@site/src/components/Download
 
 ## Homebrew
 
-`buf` can be installed for Mac or Linux using [Homebrew](https://brew.sh) via the
-[bufbuild/homebrew-buf](https://github.com/bufbuild/homebrew-buf) tap.
+You can install `buf` on macoS or Linux using [Homebrew](https://brew.sh):
 
 ```sh
-brew tap bufbuild/buf
-brew install buf
+brew install bufbuild/buf/buf
 ```
 
 This installs:

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -20,7 +20,7 @@ import DownloadButton, {mac, linux, windows} from '@site/src/components/Download
 
 ## Homebrew
 
-You can install `buf` on macoS or Linux using [Homebrew](https://brew.sh):
+You can install `buf` on macOS or Linux using [Homebrew](https://brew.sh):
 
 ```sh
 brew install bufbuild/buf/buf


### PR DESCRIPTION
Looks like Homebrew has made the old `brew tap` system unnecessary.