### PR TITLE
Fix errant param in Syntax component

### DIFF
--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -85,7 +85,7 @@ import Syntax from "@site/src/components/Syntax";
 
 <Syntax
   title="Synthetic version syntax"
-  example="v1.3.5"
+  examples={["v1.3.5"]}
   segments={[
     {label: "v1", kind: "static"},
     {separator: "."},


### PR DESCRIPTION
This should be `examples` and not `example`.
