### PR TITLE
Mention remote code gen as alpha rather than experimental

### DIFF
--- a/docs/bsr/introduction.md
+++ b/docs/bsr/introduction.md
@@ -26,7 +26,7 @@ The BSR comes with a browsable UI, dependency management, API validation and ver
     - *Local Code Generation*: The BSR contains remote references that allow you to immediately generate code for your language of choice. Use your existing `protoc` plugins,
       run `buf generate`, and you're ready to go.
 
-    - *Remote Code Generation (experimental)*: Don't want to manage plugins? No problem. The BSR offers remote code generation through hosted plugins and templates.
+    - *Remote Code Generation (alpha)*: Don't want to manage plugins? No problem. The BSR offers remote code generation through hosted plugins and templates.
       The remote-generated code gets stored in a managed software repository that you fetch like any other library with tools you already know: `go get`, `mvn install`,
       `pip install`, `npm install`, etc.
 
@@ -82,6 +82,6 @@ Here are a few ways to get moving:
 
 ## Experimental features
 
-[Remote Generation](remote-generation/overview.md) is currently an *experimental feature*. This feature lets the BSR generate data types and service stubs for your modules and store the generated code in a **hosted registry**. With this, you can consume the generated code like any other library in your language of choice.
+[Remote Generation](remote-generation/overview.md) is currently an *alpha feature*. This feature lets the BSR generate data types and service stubs for your modules and store the generated code in a **hosted registry**. With this, you can consume the generated code like any other library in your language of choice.
 
 > Note, this feature is currently available for Go. But we have plans to add additional support for other languages.

--- a/docs/bsr/remote-generation/concepts.md
+++ b/docs/bsr/remote-generation/concepts.md
@@ -3,7 +3,7 @@ id: concepts
 title: Key Concepts
 ---
 
-> Remote code generation is an **experimental feature**. We started with Go and have plans to add support for other languages. [Let us know what language we should tackle next](../../contact.md).
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 ## Plugins
 

--- a/docs/bsr/remote-generation/consuming-generated-code.md
+++ b/docs/bsr/remote-generation/consuming-generated-code.md
@@ -3,7 +3,7 @@ id: consume-generated-go-code
 title: Consume Generated Go Code
 ---
 
-> Remote code generation is an **experimental feature**. We started with Go and have plans to add support for other languages. [Let us know what language we should tackle next](../../contact.md).
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 Now that the BSR supports **remote code generation**, you no longer have to maintain Protobuf files, `protoc`-based plugins or generate code locally. This is especially useful for API clients, who just want a Go SDK to start consuming an API immediately.
 

--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -4,9 +4,7 @@ title: Overview
 description: The BSR supports remote code generation, which means you fetch generated source code like any other dependency.
 ---
 
-import Image from '@site/src/components/Image';
-
-> Remote code generation is an **experimental feature**. We started with Go and have plans to add support for other languages. [Let us know what language we should tackle next](../../contact.md).
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 A common frustration when working with Protobuf is the dependency on language
 specific generated code. Many teams implement custom tooling and scripts
@@ -17,6 +15,8 @@ tooling set up locally.
 Furthermore, if you have Protobuf-based services your clients shouldn't have to deal
 with code generation. They should be able to consume your API immediately. *And* it should
 be as simple as pulling a generated client from their language's registry, that's it!
+
+import Image from '@site/src/components/Image';
 
 <Image alt="BSR module" src="/img/bsr/remote-code-gen.png" width={75} caption="The Buf Schema Registry's remote generation process" />
 

--- a/docs/bsr/remote-generation/plugin-example.md
+++ b/docs/bsr/remote-generation/plugin-example.md
@@ -3,7 +3,7 @@ id: plugin-example
 title: Authoring a Plugin
 ---
 
-> Remote code generation is an **experimental feature**. We started with Go and have plans to add support for other languages. [Let us know what language we should tackle next](../../contact.md).
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 The purpose of this guide is to walk you through a concrete example of how to publish an existing `protoc`-based plugin to the BSR.
 

--- a/docs/bsr/remote-generation/template-example.md
+++ b/docs/bsr/remote-generation/template-example.md
@@ -3,7 +3,7 @@ id: template-example
 title: Authoring a Template
 ---
 
-> Remote code generation is an **experimental feature**. We started with Go and have plans to add support for other languages. [Let us know what language we should tackle next](../../contact.md).
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 A BSR Template is a collection of one or more plugins that facilitates remote code generation.
 

--- a/docs/bsr/usage.md
+++ b/docs/bsr/usage.md
@@ -156,7 +156,7 @@ This generates C++ and Java code in the local `/gen/proto/{cpp,java}` directorie
 
 ### Remote code generation
 
-If you don't want to manage plugins and generate code manually, and instead would prefer to simply consume generated code, check out the experimental [Remote Code Generation](../bsr/remote-generation/overview.md) section.
+If you don't want to manage plugins and generate code manually and would prefer to simply consume generated code, check out the [remote code generation](../bsr/remote-generation/overview.md) feature, which is currently in **alpha**.
 
 ### Deprecate or undeprecate a repository
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,8 +19,9 @@ One of the promises of the BSR is to allow the generation of your APIs on demand
 we want to enable modules to have stubs generated on-demand, for every version, for every possible
 Protobuf plugin, with consumption via language-native mechanisms.
 
-This feature is currently available for Buf's *experimental* [Go Module Proxy](bsr/remote-generation/overview.md#go-module-proxy).
-Given a module, such as `buf.build/acme/weather`, you can consume generated code for:
+This feature is currently available for Buf's [Go Module Proxy](bsr/remote-generation/overview.md#go-module-proxy)
+which is currently in **alpha**. Given a module, such as `buf.build/acme/weather`, you can consume
+generated code for:
 
   - Plugin `protoc-gen-go` version `1.4.0`
   - Plugin `protoc-gen-go-grpc` version `1.0.0`

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -3,8 +3,7 @@ id: use-remote-generation
 title: 16 Bonus — Use Remote Generation
 ---
 
-> The [Remote Generation](../bsr/remote-generation/overview.md) feature is **experimental** and
-> thus likely to change.
+> The [remote code generation](/bsr/remote-generation/overview) feature is currently in **alpha**. We started with Go and have plans to add support for other languages. [Let us know](/contact.md) which language we should tackle next.
 
 In this section, you'll learn how to use Buf's Go Module Proxy to import the Go/gRPC client and
 server stubs as you would import any other Go library. Remote Generation thus reduces the code

--- a/docs/tour/wrapping-up.md
+++ b/docs/tour/wrapping-up.md
@@ -8,5 +8,5 @@ directory, with the exception of the difference between the `acme` organization 
 files and your own personal `$BUF_USER`).
 
 For more information on the concepts you went over here, please continue to read through the rest of
-the documentation, or take a look at the experimental [Remote
-Generation](/tour/use-remote-generation) feature in the next step!
+the documentation, or take a look at the [Remote
+Generation](/tour/use-remote-generation) feature (currently in **alpha**) in the next step!


### PR DESCRIPTION
This brings our docs in line with the sidebar badge for remote code gen. I don't see any real distinction between alpha and experimental, and if we _do_ have such a distinction we should probably ditch it 😄