### PR TITLE
Add dedicated CLI docs

### DIFF
--- a/docs/reference/cll.md
+++ b/docs/reference/cll.md
@@ -1,0 +1,9 @@
+---
+id: cli
+title: Command-line interface
+---
+
+import Cli from '@site/src/components/Cli';
+
+<!-- This component is generated from the data in src/components/Cli/commands.ts -->
+<Cli />

--- a/sidebars.js
+++ b/sidebars.js
@@ -143,6 +143,7 @@ const sidebars = {
       type: "category",
       label: "Reference",
       items: [
+        "reference/cli",
         "reference/workspaces",
         "reference/images",
         "reference/inputs",

--- a/src/components/Cli/args.ts
+++ b/src/components/Cli/args.ts
@@ -1,0 +1,109 @@
+import { link } from './links';
+
+type Arg = {
+  name: string;
+  description: string;
+  default?: string;
+};
+
+const commitArg: Arg = {
+  name: "commit",
+  description: "BSR commit"
+};
+
+const directoryArg: Arg = {
+  name: "directory",
+  description: "A directory.",
+  default: "."
+};
+
+const inputArg: Arg = {
+  name: "input",
+  description: `The ${link("inputs", "Buf input")}.`,
+  default: "."
+};
+
+const moduleArg: Arg = {
+  name: "module",
+  description: "A reference to a Buf module."
+};
+
+const organizationArg: Arg = {
+  name: "organization",
+  description: "The BSR organization."
+};
+
+const pluginArg: Arg = {
+  name: "plugin",
+  description: "The BSR plugin."
+};
+
+const referenceArg: Arg = {
+  name: "reference",
+  description: "A reference."
+};
+
+const registryArg: Arg = {
+  name: "registry",
+  description: "The schema registry.",
+  default: "buf.build"
+};
+
+const repositoryArg: Arg = {
+  name: "repository",
+  description: "The BSR repository."
+};
+
+const sourceArg: Arg = {
+  name: "source",
+  description: "A Buf source."
+};
+
+const tagArg: Arg = {
+  name: "tag",
+  description: "A BSR tag."
+};
+
+const templateArg: Arg = {
+  name: "template",
+  description: "A BSR code generation template."
+};
+
+const trackArg: Arg = {
+  name: "track",
+  description: "A BSR track."
+};
+
+const args: Arg[] = [
+  commitArg,
+  directoryArg,
+  inputArg,
+  moduleArg,
+  organizationArg,
+  pluginArg,
+  referenceArg,
+  registryArg,
+  repositoryArg,
+  sourceArg,
+  tagArg,
+  templateArg,
+  trackArg
+];
+
+export {
+  Arg,
+  args,
+  commitArg,
+  directoryArg,
+  inputArg,
+  moduleArg,
+  organizationArg,
+  pluginArg,
+  referenceArg,
+  registryArg,
+  repositoryArg,
+  sourceArg,
+  tagArg,
+  templateArg,
+  trackArg
+}

--- a/src/components/Cli/args.ts
+++ b/src/components/Cli/args.ts
@@ -90,8 +90,9 @@ const args: Arg[] = [
   trackArg
 ];
 
+export default Arg;
+
 export {
-  Arg,
   args,
   commitArg,
   directoryArg,

--- a/src/components/Cli/args.ts
+++ b/src/components/Cli/args.ts
@@ -1,9 +1,9 @@
-import { link } from "./links";
+import { link } from './links';
 
 type Arg = {
   name: string;
   description: string;
-  default?: string;
+  argDefault?: string;
 };
 
 const commitArg: Arg = {
@@ -14,13 +14,13 @@ const commitArg: Arg = {
 const directoryArg: Arg = {
   name: "directory",
   description: "A directory.",
-  default: "."
+  argDefault: "."
 };
 
 const inputArg: Arg = {
   name: "input",
   description: `The ${link("inputs", "Buf input")}.`,
-  default: "."
+  argDefault: "."
 };
 
 const moduleArg: Arg = {
@@ -46,7 +46,7 @@ const referenceArg: Arg = {
 const registryArg: Arg = {
   name: "registry",
   description: "The schema registry.",
-  default: "buf.build"
+  argDefault: "buf.build"
 };
 
 const repositoryArg: Arg = {

--- a/src/components/Cli/args.ts
+++ b/src/components/Cli/args.ts
@@ -1,4 +1,4 @@
-import { link } from './links';
+import { link } from "./links";
 
 type Arg = {
   name: string;
@@ -107,4 +107,4 @@ export {
   tagArg,
   templateArg,
   trackArg
-}
+};

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -1,5 +1,4 @@
-import {
-  Arg,
+import Arg, {
   commitArg,
   directoryArg,
   inputArg,
@@ -14,6 +13,28 @@ import {
   templateArg,
   trackArg,
 } from './args';
+import Flag, {
+  allFlag,
+  configFlag,
+  disableSymlinksFlag,
+  errorFormatFlag,
+  excludeImportsFlag,
+  excludePathFlag,
+  forceFlag,
+  formatFlag,
+  inputFlag,
+  lsConfigFlag,
+  lsVersionFlag,
+  messageFlag,
+  outputFlag,
+  pageSizeFlag,
+  pageTokenFlag,
+  pathFlag,
+  reverseFlag,
+  templateConfigFlag,
+  typeFlag,
+  visibilityFlag,
+} from './flags';
 import { link } from './links';
 
 type Command = {
@@ -21,6 +42,7 @@ type Command = {
   description: string;
   arg?: Arg;
   args?: Arg[];
+  flags?: Flag[];
   commands?: Command[];
 };
 
@@ -33,7 +55,8 @@ const commands: Command[] = [
         name: "convert",
         description:
           "Use a source reference to convert a binary or JSON-serialized message supplied through stdin or the input flag.",
-        arg: sourceArg
+        arg: sourceArg,
+        flags: [errorFormatFlag, inputFlag, outputFlag, typeFlag]
       },
       {
         name: "migrate-v1beta1",
@@ -52,12 +75,14 @@ const commands: Command[] = [
               {
                 name: "get",
                 description: "",
-                arg: referenceArg
+                arg: referenceArg,
+                flags: [formatFlag]
               },
               {
                 name: "list",
                 description: "",
                 arg: moduleArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               }
             ]
           },
@@ -69,16 +94,19 @@ const commands: Command[] = [
                 name: "create",
                 description: "",
                 arg: organizationArg,
+                flags: [formatFlag]
               },
               {
                 name: "delete",
                 description: "",
                 arg: organizationArg,
+                flags: [forceFlag]
               },
               {
                 name: "get",
                 description: "",
                 arg: organizationArg,
+                flags: [formatFlag]
               }
             ]
           },
@@ -90,26 +118,30 @@ const commands: Command[] = [
                 name: "create",
                 description: "",
                 arg: pluginArg,
+                flags: [formatFlag, visibilityFlag("plugin")]
               },
               {
                 name: "delete",
                 description: "",
                 arg: pluginArg,
+                flags: [forceFlag]
               },
               {
                 name: "deprecate",
                 description: "",
                 arg: pluginArg,
+                flags: [messageFlag]
               },
               {
                 name: "list",
                 description: "",
                 arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               },
               {
                 name: "undeprecate",
                 description: "",
-                arg: pluginArg,
+                arg: pluginArg
               },
               {
                 name: "version",
@@ -119,6 +151,7 @@ const commands: Command[] = [
                     name: "list",
                     description: "List versions.",
                     arg: pluginArg,
+                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
                   }
                 ]
               }
@@ -132,31 +165,36 @@ const commands: Command[] = [
                 name: "create",
                 description: "",
                 arg: repositoryArg,
+                flags: [formatFlag, visibilityFlag("repository")]
               },
               {
                 name: "delete",
                 description: "",
                 arg: repositoryArg,
+                flags: [forceFlag]
               },
               {
                 name: "deprecate",
                 description: "",
                 arg: repositoryArg,
+                flags: [messageFlag]
               },
               {
                 name: "get",
                 description: "",
                 arg: repositoryArg,
+                flags: [formatFlag]
               },
               {
                 name: "list",
                 description: "",
                 arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               },
               {
                 name: "undeprecate",
                 description: "",
-                arg: repositoryArg,
+                arg: repositoryArg
               }
             ]
           },
@@ -167,12 +205,12 @@ const commands: Command[] = [
               {
                 name: "create",
                 description: "",
-                args: [commitArg, tagArg],
+                args: [commitArg, tagArg]
               },
               {
                 name: "list",
                 description: "",
-                arg: repositoryArg,
+                arg: repositoryArg
               }
             ]
           },
@@ -184,26 +222,30 @@ const commands: Command[] = [
                 name: "create",
                 description: "",
                 arg: templateArg,
+                flags: [templateConfigFlag, formatFlag, visibilityFlag("template")]
               },
               {
                 name: "delete",
                 description: "",
                 arg: templateArg,
+                flags: [forceFlag]
               },
               {
                 name: "deprecate",
                 description: "",
-                arg: templateArg
+                arg: templateArg,
+                flags: [messageFlag]
               },
               {
                 name: "list",
                 description: "",
-                arg: registryArg
+                arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               },
               {
                 name: "undeprecate",
                 description: "",
-                arg: templateArg,
+                arg: templateArg
               },
               {
                 name: "version",
@@ -212,12 +254,14 @@ const commands: Command[] = [
                   {
                     name: "create",
                     description: "Create a new template version",
-                    arg: templateArg
+                    arg: templateArg,
+                    flags: [templateConfigFlag, formatFlag]
                   },
                   {
                     name: "list",
                     description: "List versions for the specified template.",
                     arg: templateArg,
+                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
                   }
                 ]
               }
@@ -231,11 +275,13 @@ const commands: Command[] = [
                 name: "delete",
                 description: "",
                 arg: trackArg,
+                flags: [forceFlag]
               },
               {
                 name: "list",
                 description: "",
                 arg: repositoryArg,
+                args: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               }
             ]
           }
@@ -247,11 +293,89 @@ const commands: Command[] = [
     name: "breaking",
     description: "Breaking change detection",
     arg: inputArg,
+    flags: [
+      {
+        name: "against",
+        description: "The source, module, or image to check against.",
+        type: "string",
+        enum: {
+          bin: "Binary",
+          dir: "Directory",
+          git: "Git repository",
+          json: "JSON",
+          mod: "Buf module",
+          protofile: "Protobuf file",
+          tar: "Tarball",
+          zip: "ZIP file"
+        },
+        multiple: false
+      },
+      {
+        name: "against-config",
+        description: "The file or data to use to configure the against source, module, or image.",
+        type: "string",
+        multiple: false
+      },
+      configFlag,
+      disableSymlinksFlag,
+      errorFormatFlag,
+      excludeImportsFlag,
+      excludePathFlag,
+      {
+        name: "limit-to-input-files",
+        description: `Only run breaking change detection against the files in the input.
+
+When set, the against input contains only the files in the input. This overrides the <code>--path</code> setting.`,
+        multiple: false
+      },
+      pathFlag
+    ]
   },
   {
     name: "build",
     description: "Build",
-    arg: inputArg
+    arg: inputArg,
+    flags: [
+      {
+        name: "as-file-descriptor-set",
+        description: `Output as a <code>google.protobuf.FileDescriptorSet</code> instead of a Buf image.
+
+Note that Buf images are wire compatible with <code>FileDescriptorSet</code>s, but this flag strips the additional metadata added for Buf usage.`,
+        multiple: false
+      },
+      configFlag,
+      disableSymlinksFlag,
+      errorFormatFlag,
+      excludeImportsFlag,
+      excludePathFlag,
+      {
+        name: "exclude-source-info",
+        description: "Exclude source info.",
+        multiple: false
+      },
+      {
+        name: "output",
+        description: "The output location for the built Buf image.",
+        type: "string",
+        default: "/dev/null",
+        enum: {
+          bin: "Binary",
+          json: "JSON"
+        },
+        multiple: false
+      },
+      {
+        name: "type",
+        description:
+          "The types (message, enum, service) that should be included in this Buf image. When specified, the resulting image includes only the descriptors needed to describe the requested types.",
+        type: "strings",
+        docLink: {
+          name: "Limit to specific types",
+          url: "/build/usage#limit-to-specific-types"
+        },
+        multiple: true
+      }
+    ]
   },
   {
     name: "completion",
@@ -278,21 +402,90 @@ const commands: Command[] = [
   {
     name: "export",
     description: "Export",
-    arg: inputArg
+    arg: inputArg,
+    flags: [
+      configFlag,
+      disableSymlinksFlag,
+      excludeImportsFlag,
+      excludePathFlag,
+      {
+        name: "output",
+        description: "The output directory for exported files.",
+        short: "o",
+        type: "string",
+        multiple: false
+      },
+      {
+        name: "path",
+        description: `Limit to specific files or directories, such as <code>proto/a/a.proto</code> or <code>proto/a</code>.
+
+If specified multiple times, the union is taken.`,
+        multiple: false
+      }
+    ]
   },
   {
     name: "generate",
     description: "Generate code stubs",
-    arg: inputArg
+    arg: inputArg,
+    flags: [
+      configFlag,
+      disableSymlinksFlag,
+      errorFormatFlag,
+      excludePathFlag,
+      {
+        name: "include-imports",
+        description: "Also generate all imports except for Well-Known Types.",
+        multiple: false
+      },
+      {
+        name: "include-wkt",
+        description:
+          "Also generate Well-Known Types. Can't be set without <code>--include-imports</code>.",
+        multiple: false
+      },
+      {
+        name: "ouput",
+        description:
+          "The base directory to generate to. This is prepended to the <code>out</code> directories in the generation template.",
+        type: "string",
+        default: ".",
+        multiple: false
+      },
+      pathFlag,
+      {
+        name: "template",
+        description:
+          "The generation template file or data to use. Must be in either YAML or JSON format.",
+        type: "string",
+        multiple: false
+      }
+    ]
   },
   {
     name: "lint",
     description: "Lint Protobuf sources",
-    arg: inputArg
+    arg: inputArg,
+    flags: [configFlag, disableSymlinksFlag, errorFormatFlag, excludePathFlag, pathFlag]
   },
   {
     name: "ls-files",
-    description: "List all Protobuf files for the input."
+    description: "List all Protobuf files for the input.",
+    flags: [
+      {
+        name: "as-import-paths",
+        description: "Strip local directory paths and print filepaths as they're imported.",
+        multiple: false
+      },
+      configFlag,
+      disableSymlinksFlag,
+      errorFormatFlag,
+      {
+        name: "include-imports",
+        description: "Include imports.",
+        multiple: false
+      }
+    ]
   },
   {
     name: "mod",
@@ -304,20 +497,30 @@ const commands: Command[] = [
       },
       {
         name: "init",
-        description: ""
+        description: "",
+        flags: [
+          {
+            name: "doc",
+            description:
+              "Write inline documentation in the form of comments in the resulting configuration <code>buf.yaml</code> file.",
+            multiple: false
+          }
+        ]
       },
       {
         name: "ls-breaking-rules",
-        description: ""
+        description: "",
+        flags: [allFlag, lsConfigFlag, formatFlag, lsVersionFlag]
       },
       {
         name: "ls-lint-rules",
-        description: ""
+        description: "",
+        flags: [allFlag, lsConfigFlag, formatFlag, lsVersionFlag]
       },
       {
         name: "open",
         description: "",
-        arg: directoryArg,
+        arg: directoryArg
       },
       {
         name: "prune",
@@ -328,13 +531,41 @@ const commands: Command[] = [
         name: "update",
         description: "",
         arg: directoryArg,
+        flags: [
+          {
+            name: "only",
+            description:
+              "The name of the dependency to update. When set, only this dependency is updated, along with any of its sub-dependencies.",
+            type: "strings",
+            multiple: true
+          }
+        ]
       }
     ]
   },
   {
     name: "push",
     description: "Push a module to the BSR.",
-    arg: sourceArg
+    arg: sourceArg,
+    flags: [
+      disableSymlinksFlag,
+      errorFormatFlag,
+      {
+        name: "tag",
+        description:
+          "Create a tag for the pushed commit. Multiple tags are created if specified multiple times.",
+        short: "t",
+        type: "strings",
+        multiple: true
+      },
+      {
+        name: "track",
+        description:
+          "Append the pushed module to this track. Multiple tracks are appended if specified multiple times.",
+        type: "strings",
+        multiple: true
+      }
+    ]
   },
   {
     name: "registry",
@@ -342,18 +573,29 @@ const commands: Command[] = [
     commands: [
       {
         name: "login",
-        description: ""
+        description: `Log into the ${link("bsr", "Buf Schema Registry")}.`,
+        flags: [
+          {
+            name: "token-stdin",
+            description:
+              "Read the BSR token from stdin. This command prompts for a token by default.",
+            multiple: false
+          },
+          {
+            name: "username",
+            description: "Your BSR username. This command prompts for a username by default.",
+            multiple: false
+          }
+        ]
       },
       {
         name: "logout",
-        description: ""
+        description: `Log out of the ${link("bsr", "Buf Schema Registry")}.`
       }
     ]
   }
 ];
 
-export {
-  Command,
-  commands,
-  link
-}
+export default Command;
+
+export { commands, link };

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -1,27 +1,45 @@
-import { Command } from '.';
+import {
+  Arg,
+  commitArg,
+  directoryArg,
+  inputArg,
+  moduleArg,
+  organizationArg,
+  pluginArg,
+  referenceArg,
+  registryArg,
+  repositoryArg,
+  sourceArg,
+  tagArg,
+  templateArg,
+  trackArg,
+} from './args';
+import { link } from './links';
 
-
-const links: Record<string, string> = {
-  bsr: "/bsr/overview",
+type Command = {
+  name: string;
+  description: string;
+  arg?: Arg;
+  args?: Arg[];
+  commands?: Command[];
 };
 
-const link = (name: string, text?: string): string => {
-  const txt = (text) ? text : name;
-  return `<a href="${links[name]}">${txt}</a>`
-}
-
-export const commands: Command[] = [
+const commands: Command[] = [
   {
     name: "beta",
     description: "Beta commands. Unstable and likely to change.",
     commands: [
       {
         name: "convert",
-        description: "Use a source reference to convert a binary or JSON-serialized message supplied through stdin or the input flag."
+        description:
+          "Use a source reference to convert a binary or JSON-serialized message supplied through stdin or the input flag.",
+        arg: sourceArg
       },
       {
         name: "migrate-v1beta1",
-        description: "Migrate any v1beta1 configuration files in the current directory to the latest version."
+        description:
+          "Migrate any v1beta1 configuration files in the current directory to the latest version.",
+        arg: directoryArg
       },
       {
         name: "registry",
@@ -33,11 +51,13 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "get",
-                description: ""
+                description: "",
+                arg: referenceArg
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: moduleArg,
               }
             ]
           },
@@ -47,15 +67,18 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "create",
-                description: ""
+                description: "",
+                arg: organizationArg,
               },
               {
                 name: "delete",
-                description: ""
+                description: "",
+                arg: organizationArg,
               },
               {
                 name: "get",
-                description: ""
+                description: "",
+                arg: organizationArg,
               }
             ]
           },
@@ -65,27 +88,39 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "create",
-                description: ""
+                description: "",
+                arg: pluginArg,
               },
               {
                 name: "delete",
-                description: ""
+                description: "",
+                arg: pluginArg,
               },
               {
                 name: "deprecate",
-                description: ""
+                description: "",
+                arg: pluginArg,
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: registryArg,
               },
               {
                 name: "undeprecate",
-                description: ""
+                description: "",
+                arg: pluginArg,
               },
               {
                 name: "version",
-                description: ""
+                description: "",
+                commands: [
+                  {
+                    name: "list",
+                    description: "List versions.",
+                    arg: pluginArg,
+                  }
+                ]
               }
             ]
           },
@@ -95,27 +130,33 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "create",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               },
               {
                 name: "delete",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               },
               {
                 name: "deprecate",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               },
               {
                 name: "get",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: registryArg,
               },
               {
                 name: "undeprecate",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               }
             ]
           },
@@ -125,11 +166,13 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "create",
-                description: ""
+                description: "",
+                args: [commitArg, tagArg],
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               }
             ]
           },
@@ -139,27 +182,44 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "create",
-                description: ""
+                description: "",
+                arg: templateArg,
               },
               {
                 name: "delete",
-                description: ""
+                description: "",
+                arg: templateArg,
               },
               {
                 name: "deprecate",
-                description: ""
+                description: "",
+                arg: templateArg
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: registryArg
               },
               {
                 name: "undeprecate",
-                description: ""
+                description: "",
+                arg: templateArg,
               },
               {
                 name: "version",
-                description: ""
+                description: "",
+                commands: [
+                  {
+                    name: "create",
+                    description: "Create a new template version",
+                    arg: templateArg
+                  },
+                  {
+                    name: "list",
+                    description: "List versions for the specified template.",
+                    arg: templateArg,
+                  }
+                ]
               }
             ]
           },
@@ -169,11 +229,13 @@ export const commands: Command[] = [
             commands: [
               {
                 name: "delete",
-                description: ""
+                description: "",
+                arg: trackArg,
               },
               {
                 name: "list",
-                description: ""
+                description: "",
+                arg: repositoryArg,
               }
             ]
           }
@@ -183,11 +245,13 @@ export const commands: Command[] = [
   },
   {
     name: "breaking",
-    description: "Breaking change detection"
+    description: "Breaking change detection",
+    arg: inputArg,
   },
   {
     name: "build",
-    description: "Build"
+    description: "Build",
+    arg: inputArg
   },
   {
     name: "completion",
@@ -213,11 +277,18 @@ export const commands: Command[] = [
   },
   {
     name: "export",
-    description: "Export"
+    description: "Export",
+    arg: inputArg
+  },
+  {
+    name: "generate",
+    description: "Generate code stubs",
+    arg: inputArg
   },
   {
     name: "lint",
-    description: "Lint Protobuf sources"
+    description: "Lint Protobuf sources",
+    arg: inputArg
   },
   {
     name: "ls-files",
@@ -245,21 +316,25 @@ export const commands: Command[] = [
       },
       {
         name: "open",
-        description: ""
+        description: "",
+        arg: directoryArg,
       },
       {
         name: "prune",
-        description: ""
+        description: "",
+        arg: directoryArg
       },
       {
         name: "update",
-        description: ""
+        description: "",
+        arg: directoryArg,
       }
     ]
   },
   {
     name: "push",
-    description: "Push a module to the BSR."
+    description: "Push a module to the BSR.",
+    arg: sourceArg
   },
   {
     name: "registry",
@@ -276,3 +351,9 @@ export const commands: Command[] = [
     ]
   }
 ];
+
+export {
+  Command,
+  commands,
+  link
+}

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -1,0 +1,278 @@
+import { Command } from '.';
+
+
+const links: Record<string, string> = {
+  bsr: "/bsr/overview",
+};
+
+const link = (name: string, text?: string): string => {
+  const txt = (text) ? text : name;
+  return `<a href="${links[name]}">${txt}</a>`
+}
+
+export const commands: Command[] = [
+  {
+    name: "beta",
+    description: "Beta commands. Unstable and likely to change.",
+    commands: [
+      {
+        name: "convert",
+        description: "Use a source reference to convert a binary or JSON-serialized message supplied through stdin or the input flag."
+      },
+      {
+        name: "migrate-v1beta1",
+        description: "Migrate any v1beta1 configuration files in the current directory to the latest version."
+      },
+      {
+        name: "registry",
+        description: `Manage assets on the ${link("bsr", "Buf Schema Registry")} (BSR).`,
+        commands: [
+          {
+            name: "commit",
+            description: "",
+            commands: [
+              {
+                name: "get",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "organization",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: ""
+              },
+              {
+                name: "delete",
+                description: ""
+              },
+              {
+                name: "get",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "plugin",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: ""
+              },
+              {
+                name: "delete",
+                description: ""
+              },
+              {
+                name: "deprecate",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              },
+              {
+                name: "undeprecate",
+                description: ""
+              },
+              {
+                name: "version",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "repository",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: ""
+              },
+              {
+                name: "delete",
+                description: ""
+              },
+              {
+                name: "deprecate",
+                description: ""
+              },
+              {
+                name: "get",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              },
+              {
+                name: "undeprecate",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "tag",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "template",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: ""
+              },
+              {
+                name: "delete",
+                description: ""
+              },
+              {
+                name: "deprecate",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              },
+              {
+                name: "undeprecate",
+                description: ""
+              },
+              {
+                name: "version",
+                description: ""
+              }
+            ]
+          },
+          {
+            name: "track",
+            description: "",
+            commands: [
+              {
+                name: "delete",
+                description: ""
+              },
+              {
+                name: "list",
+                description: ""
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    name: "breaking",
+    description: "Breaking change detection"
+  },
+  {
+    name: "build",
+    description: "Build"
+  },
+  {
+    name: "completion",
+    description: "Shell auto-complete scripts",
+    commands: [
+      {
+        name: "bash",
+        description: "Generate auto-completion scripts for bash."
+      },
+      {
+        name: "fish",
+        description: "Generate auto-completion scripts for fish."
+      },
+      {
+        name: "powershell",
+        description: "Generate auto-completion scripts for Powershell."
+      },
+      {
+        name: "zsh",
+        description: "Generate auto-completion scripts for zsh."
+      }
+    ]
+  },
+  {
+    name: "export",
+    description: "Export"
+  },
+  {
+    name: "lint",
+    description: "Lint Protobuf sources"
+  },
+  {
+    name: "ls-files",
+    description: "List all Protobuf files for the input."
+  },
+  {
+    name: "mod",
+    description: "Modules",
+    commands: [
+      {
+        name: "clear-cache",
+        description: ""
+      },
+      {
+        name: "init",
+        description: ""
+      },
+      {
+        name: "ls-breaking-rules",
+        description: ""
+      },
+      {
+        name: "ls-lint-rules",
+        description: ""
+      },
+      {
+        name: "open",
+        description: ""
+      },
+      {
+        name: "prune",
+        description: ""
+      },
+      {
+        name: "update",
+        description: ""
+      }
+    ]
+  },
+  {
+    name: "push",
+    description: "Push a module to the BSR."
+  },
+  {
+    name: "registry",
+    description: "Buf Schema Registry commands",
+    commands: [
+      {
+        name: "login",
+        description: ""
+      },
+      {
+        name: "logout",
+        description: ""
+      }
+    ]
+  }
+];

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -1,4 +1,5 @@
 import Arg, {
+  args,
   commitArg,
   directoryArg,
   inputArg,
@@ -178,6 +179,31 @@ Note that Buf images are wire compatible with <code>FileDescriptorSet</code>s, b
         description: `Limit to specific files or directories, such as <code>proto/a/a.proto</code> or <code>proto/a</code>.
 
 If specified multiple times, the union is taken.`,
+        multiple: false
+      }
+    ]
+  },
+  {
+    name: "format",
+    description: "Format Protobuf files.",
+    arg: inputArg,
+    flags: [
+      configFlag,
+      {
+        name: "diff",
+        short: "d",
+        description: "Display diffs instead of rewriting files.",
+        multiple: false
+      },
+      disableSymlinksFlag,
+      errorFormatFlag,
+      excludePathFlag,
+      outputFlag,
+      pathFlag,
+      {
+        name: "write",
+        short: "w",
+        description: "Rewrite files in place.",
         multiple: false
       }
     ]

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -281,7 +281,7 @@ const commands: Command[] = [
                 name: "list",
                 description: "",
                 arg: repositoryArg,
-                args: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
               }
             ]
           }

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -11,8 +11,8 @@ import Arg, {
   sourceArg,
   tagArg,
   templateArg,
-  trackArg,
-} from './args';
+  trackArg
+} from "./args";
 import Flag, {
   allFlag,
   configFlag,
@@ -33,9 +33,9 @@ import Flag, {
   reverseFlag,
   templateConfigFlag,
   typeFlag,
-  visibilityFlag,
-} from './flags';
-import { link } from './links';
+  visibilityFlag
+} from "./flags";
+import { link } from "./links";
 
 type Command = {
   name: string;

--- a/src/components/Cli/commands.ts
+++ b/src/components/Cli/commands.ts
@@ -11,8 +11,8 @@ import Arg, {
   sourceArg,
   tagArg,
   templateArg,
-  trackArg
-} from "./args";
+  trackArg,
+} from './args';
 import Flag, {
   allFlag,
   configFlag,
@@ -33,9 +33,9 @@ import Flag, {
   reverseFlag,
   templateConfigFlag,
   typeFlag,
-  visibilityFlag
-} from "./flags";
-import { link } from "./links";
+  visibilityFlag,
+} from './flags';
+import { link } from './links';
 
 type Command = {
   name: string;
@@ -47,248 +47,6 @@ type Command = {
 };
 
 const commands: Command[] = [
-  {
-    name: "beta",
-    description: "Beta commands. Unstable and likely to change.",
-    commands: [
-      {
-        name: "convert",
-        description:
-          "Use a source reference to convert a binary or JSON-serialized message supplied through stdin or the input flag.",
-        arg: sourceArg,
-        flags: [errorFormatFlag, inputFlag, outputFlag, typeFlag]
-      },
-      {
-        name: "migrate-v1beta1",
-        description:
-          "Migrate any v1beta1 configuration files in the current directory to the latest version.",
-        arg: directoryArg
-      },
-      {
-        name: "registry",
-        description: `Manage assets on the ${link("bsr", "Buf Schema Registry")} (BSR).`,
-        commands: [
-          {
-            name: "commit",
-            description: "",
-            commands: [
-              {
-                name: "get",
-                description: "",
-                arg: referenceArg,
-                flags: [formatFlag]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: moduleArg,
-                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-              }
-            ]
-          },
-          {
-            name: "organization",
-            description: "",
-            commands: [
-              {
-                name: "create",
-                description: "",
-                arg: organizationArg,
-                flags: [formatFlag]
-              },
-              {
-                name: "delete",
-                description: "",
-                arg: organizationArg,
-                flags: [forceFlag]
-              },
-              {
-                name: "get",
-                description: "",
-                arg: organizationArg,
-                flags: [formatFlag]
-              }
-            ]
-          },
-          {
-            name: "plugin",
-            description: "",
-            commands: [
-              {
-                name: "create",
-                description: "",
-                arg: pluginArg,
-                flags: [formatFlag, visibilityFlag("plugin")]
-              },
-              {
-                name: "delete",
-                description: "",
-                arg: pluginArg,
-                flags: [forceFlag]
-              },
-              {
-                name: "deprecate",
-                description: "",
-                arg: pluginArg,
-                flags: [messageFlag]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: registryArg,
-                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-              },
-              {
-                name: "undeprecate",
-                description: "",
-                arg: pluginArg
-              },
-              {
-                name: "version",
-                description: "",
-                commands: [
-                  {
-                    name: "list",
-                    description: "List versions.",
-                    arg: pluginArg,
-                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            name: "repository",
-            description: "",
-            commands: [
-              {
-                name: "create",
-                description: "",
-                arg: repositoryArg,
-                flags: [formatFlag, visibilityFlag("repository")]
-              },
-              {
-                name: "delete",
-                description: "",
-                arg: repositoryArg,
-                flags: [forceFlag]
-              },
-              {
-                name: "deprecate",
-                description: "",
-                arg: repositoryArg,
-                flags: [messageFlag]
-              },
-              {
-                name: "get",
-                description: "",
-                arg: repositoryArg,
-                flags: [formatFlag]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: registryArg,
-                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-              },
-              {
-                name: "undeprecate",
-                description: "",
-                arg: repositoryArg
-              }
-            ]
-          },
-          {
-            name: "tag",
-            description: "",
-            commands: [
-              {
-                name: "create",
-                description: "",
-                args: [commitArg, tagArg]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: repositoryArg
-              }
-            ]
-          },
-          {
-            name: "template",
-            description: "",
-            commands: [
-              {
-                name: "create",
-                description: "",
-                arg: templateArg,
-                flags: [templateConfigFlag, formatFlag, visibilityFlag("template")]
-              },
-              {
-                name: "delete",
-                description: "",
-                arg: templateArg,
-                flags: [forceFlag]
-              },
-              {
-                name: "deprecate",
-                description: "",
-                arg: templateArg,
-                flags: [messageFlag]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: registryArg,
-                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-              },
-              {
-                name: "undeprecate",
-                description: "",
-                arg: templateArg
-              },
-              {
-                name: "version",
-                description: "",
-                commands: [
-                  {
-                    name: "create",
-                    description: "Create a new template version",
-                    arg: templateArg,
-                    flags: [templateConfigFlag, formatFlag]
-                  },
-                  {
-                    name: "list",
-                    description: "List versions for the specified template.",
-                    arg: templateArg,
-                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            name: "track",
-            description: "",
-            commands: [
-              {
-                name: "delete",
-                description: "",
-                arg: trackArg,
-                flags: [forceFlag]
-              },
-              {
-                name: "list",
-                description: "",
-                arg: repositoryArg,
-                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  },
   {
     name: "breaking",
     description: "Breaking change detection",
@@ -591,6 +349,250 @@ If specified multiple times, the union is taken.`,
       {
         name: "logout",
         description: `Log out of the ${link("bsr", "Buf Schema Registry")}.`
+      }
+    ]
+  },
+  {
+    name: "beta",
+    description: "Beta commands. Unstable and likely to change.",
+    commands: [
+      {
+        name: "convert",
+        description: `Use a ${link(
+          "source",
+          "source reference"
+        )} to convert a binary or JSON-serialized message supplied through stdin or the input flag.`,
+        arg: sourceArg,
+        flags: [errorFormatFlag, inputFlag, outputFlag, typeFlag]
+      },
+      {
+        name: "migrate-v1beta1",
+        description:
+          "Migrate any v1beta1 configuration files in the current directory to the latest version.",
+        arg: directoryArg
+      },
+      {
+        name: "registry",
+        description: `Manage assets on the ${link("bsr", "Buf Schema Registry")} (BSR).`,
+        commands: [
+          {
+            name: "commit",
+            description: "",
+            commands: [
+              {
+                name: "get",
+                description: "",
+                arg: referenceArg,
+                flags: [formatFlag]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: moduleArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+              }
+            ]
+          },
+          {
+            name: "organization",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: "",
+                arg: organizationArg,
+                flags: [formatFlag]
+              },
+              {
+                name: "delete",
+                description: "",
+                arg: organizationArg,
+                flags: [forceFlag]
+              },
+              {
+                name: "get",
+                description: "",
+                arg: organizationArg,
+                flags: [formatFlag]
+              }
+            ]
+          },
+          {
+            name: "plugin",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: "",
+                arg: pluginArg,
+                flags: [formatFlag, visibilityFlag("plugin")]
+              },
+              {
+                name: "delete",
+                description: "",
+                arg: pluginArg,
+                flags: [forceFlag]
+              },
+              {
+                name: "deprecate",
+                description: "",
+                arg: pluginArg,
+                flags: [messageFlag]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+              },
+              {
+                name: "undeprecate",
+                description: "",
+                arg: pluginArg
+              },
+              {
+                name: "version",
+                description: "",
+                commands: [
+                  {
+                    name: "list",
+                    description: "List versions.",
+                    arg: pluginArg,
+                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            name: "repository",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: "",
+                arg: repositoryArg,
+                flags: [formatFlag, visibilityFlag("repository")]
+              },
+              {
+                name: "delete",
+                description: "",
+                arg: repositoryArg,
+                flags: [forceFlag]
+              },
+              {
+                name: "deprecate",
+                description: "",
+                arg: repositoryArg,
+                flags: [messageFlag]
+              },
+              {
+                name: "get",
+                description: "",
+                arg: repositoryArg,
+                flags: [formatFlag]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+              },
+              {
+                name: "undeprecate",
+                description: "",
+                arg: repositoryArg
+              }
+            ]
+          },
+          {
+            name: "tag",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: "",
+                args: [commitArg, tagArg]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: repositoryArg
+              }
+            ]
+          },
+          {
+            name: "template",
+            description: "",
+            commands: [
+              {
+                name: "create",
+                description: "",
+                arg: templateArg,
+                flags: [templateConfigFlag, formatFlag, visibilityFlag("template")]
+              },
+              {
+                name: "delete",
+                description: "",
+                arg: templateArg,
+                flags: [forceFlag]
+              },
+              {
+                name: "deprecate",
+                description: "",
+                arg: templateArg,
+                flags: [messageFlag]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: registryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+              },
+              {
+                name: "undeprecate",
+                description: "",
+                arg: templateArg
+              },
+              {
+                name: "version",
+                description: "",
+                commands: [
+                  {
+                    name: "create",
+                    description: "Create a new template version",
+                    arg: templateArg,
+                    flags: [templateConfigFlag, formatFlag]
+                  },
+                  {
+                    name: "list",
+                    description: "List versions for the specified template.",
+                    arg: templateArg,
+                    flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            name: "track",
+            description: "",
+            commands: [
+              {
+                name: "delete",
+                description: "",
+                arg: trackArg,
+                flags: [forceFlag]
+              },
+              {
+                name: "list",
+                description: "",
+                arg: repositoryArg,
+                flags: [formatFlag, pageSizeFlag, pageTokenFlag, reverseFlag]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/src/components/Cli/flags.ts
+++ b/src/components/Cli/flags.ts
@@ -1,0 +1,255 @@
+type Flag = {
+  name: string;
+  short?: string;
+  description: string;
+  type?: string;
+  default?: string;
+  enum?: Record<string, string>;
+  docLink?: {
+    name: string;
+    url: string;
+  };
+  multiple: boolean;
+};
+
+const allFlag: Flag = {
+  name: "all",
+  description: "List all available rules and not just those currently configured.",
+  multiple: false
+};
+
+const configFlag: Flag = {
+  name: "config",
+  description: "The file or data to use for configuration.",
+  type: "string",
+  multiple: false
+};
+
+const debugFlag: Flag = {
+  name: "debug",
+  description: "Turn on debug logging.",
+  multiple: false
+};
+
+const disableSymlinksFlag: Flag = {
+  name: "disable-symlinks",
+  description: "Do not follow symlinks when reading sources or configuration from the filesystem.",
+  multiple: false
+};
+
+const errorFormatFlag: Flag = {
+  name: "error-format",
+  description: "The format for build errors printed to stderr.",
+  type: "string",
+  default: "text",
+  enum: {
+    text: "Plaintext output",
+    json: "JSON output",
+    msvs: "MSVS"
+  },
+  multiple: false
+};
+
+const excludeImportsFlag: Flag = {
+  name: "exclude-imports",
+  description: "Exclude imports from breaking change detection.",
+  multiple: false
+};
+
+const excludePathFlag: Flag = {
+  name: "exclude-path",
+  description: `Exclude specific files or directories, such as <code>/proto/a/a.proto</code> or <code>proto/a</code>.
+        
+If specified more than once, the union is taken.`,
+  type: "strings",
+  multiple: true
+};
+
+const forceFlag: Flag = {
+  name: "force",
+  description: "Force deletion without confirming. Use with caution.",
+  multiple: false
+};
+
+const formatFlag: Flag = {
+  name: "format",
+  description: "The output format to use.",
+  type: "string",
+  default: "text",
+  enum: {
+    text: "Plaintext output",
+    json: "JSON output"
+  },
+  multiple: false
+};
+
+const inputFlag: Flag = {
+  name: "input",
+  description: "The location to read the input message.",
+  type: "string",
+  default: "-",
+  enum: {
+    bin: "Binary",
+    json: "JSON"
+  },
+  multiple: false
+};
+
+const logFormatFlag: Flag = {
+  name: "log-format",
+  description: "The log format.",
+  type: "string",
+  default: "color",
+  enum: {
+    text: "Plaintext output",
+    color: "Colored text output",
+    json: "JSON output"
+  },
+  multiple: false
+};
+
+const lsConfigFlag: Flag = {
+  name: "config",
+  description:
+    "The file or data to use for configuration. Ignored if <code>--all</code> or <code>--version</code> is specified.",
+  multiple: false
+};
+
+const lsVersionFlag: Flag = {
+  name: "version",
+  description:
+    "List all the rules for the given configuration version. Implies <code>--all</code>.",
+  type: "string",
+  enum: {
+    v1beta1: "Version v1beta1.",
+    v1: "Version v1."
+  },
+  multiple: false
+};
+
+const messageFlag: Flag = {
+  name: "message",
+  description: "The message to display with deprecation warnings.",
+  type: "string",
+  multiple: false
+};
+
+const outputFlag: Flag = {
+  name: "output",
+  description: "The location to write the converted result to.",
+  type: "string",
+  default: "-",
+  enum: {
+    bin: "Binary",
+    json: "JSON"
+  },
+  multiple: false
+};
+
+const pageSizeFlag: Flag = {
+  name: "page-size",
+  description: "The page size",
+  type: "uint32",
+  default: "10",
+  multiple: false
+};
+
+const pageTokenFlag: Flag = {
+  name: "page-token",
+  description:
+    "The page token. If more results are available, a <code>next_page</code> key is present in the <code>--format=json</code> output.",
+  type: "string",
+  multiple: false
+};
+
+const pathFlag: Flag = {
+  name: "path",
+  description: `Limit to specific files or directories, such as <code>proto/a/a.proto</code> or <code>proto/a</code>.
+
+If specified multiple times, the union is taken.`,
+  type: "strings",
+  multiple: true
+};
+
+const reverseFlag: Flag = {
+  name: "reverse",
+  description: "Reverse the results.",
+  multiple: false
+};
+
+const templateConfigFlag: Flag = {
+  name: "config",
+  description:
+    "The template file or data to use for configuration. Must be in either YAML or JSON format.",
+  type: "string",
+  multiple: false
+};
+
+const timeoutFlag: Flag = {
+  name: "timeout",
+  description: "The duration until timing out.",
+  type: "duration",
+  default: "2m0s",
+  multiple: false
+};
+
+const typeFlag: Flag = {
+  name: "type",
+  description:
+    "The full type name of the serialized message, such as <code>acme.weather.v1.Units</code>.",
+  type: "string",
+  multiple: false
+};
+
+const verboseFlag: Flag = {
+  name: "verbose",
+  short: "v",
+  description: "Turn on verbose mode.",
+  multiple: false
+};
+
+const visibilityFlag = (asset: string): Flag => {
+  return {
+    name: "visibility",
+    description: `The ${asset}'s visibility setting.`,
+    type: "string",
+    enum: {
+      public: "Make the asset publicly available.",
+      private: "Make the asset only private available."
+    },
+    multiple: false
+  };
+};
+
+const globalFlags: Flag[] = [debugFlag, logFormatFlag, timeoutFlag, verboseFlag];
+
+export default Flag;
+
+export {
+  allFlag,
+  configFlag,
+  debugFlag,
+  disableSymlinksFlag,
+  errorFormatFlag,
+  excludeImportsFlag,
+  excludePathFlag,
+  forceFlag,
+  formatFlag,
+  inputFlag,
+  logFormatFlag,
+  lsConfigFlag,
+  lsVersionFlag,
+  messageFlag,
+  outputFlag,
+  pageSizeFlag,
+  pageTokenFlag,
+  pathFlag,
+  reverseFlag,
+  templateConfigFlag,
+  timeoutFlag,
+  typeFlag,
+  verboseFlag,
+  visibilityFlag,
+  // Grouped tags
+  globalFlags
+};

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -16,7 +16,8 @@ const CommandEl = ({ parent, cmd }: Props) => {
   return (
     <div className={styles.cli} id={id}>
       <div className={styles.commandTitle}>
-        <span>{name}</span>
+        <a href={`#${id}`}>{name}</a>
+        
         {cmd.arg && (
           <>
             {" "}
@@ -72,7 +73,9 @@ const Cli = () => {
         <div>
           {args.map((arg) => (
             <div id={`arg-${arg.name}`}>
-              <code>{arg.name}</code>
+              <a href={`#arg-${arg.name}`}>
+                <code>{arg.name}</code>
+              </a>
 
               <div dangerouslySetInnerHTML={{ __html: arg.description }} />
 

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { args } from './args';
-import { Command, commands } from './commands';
+import Command, { commands } from './commands';
 import styles from './styles.module.css';
 
 type Props = {

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React from "react";
 
-import { args } from './args';
-import Command, { commands } from './commands';
-import styles from './styles.module.css';
+import { args } from "./args";
+import Command, { commands } from "./commands";
+import styles from "./styles.module.css";
 
 type Props = {
   parent?: string;
@@ -17,7 +17,7 @@ const CommandEl = ({ parent, cmd }: Props) => {
     <div className={styles.cli} id={id}>
       <div className={styles.commandTitle}>
         <a href={`#${id}`}>{name}</a>
-        
+
         {cmd.arg && (
           <>
             {" "}

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 
-import { commands } from './commands';
+import { args } from './args';
+import { Command, commands } from './commands';
 import styles from './styles.module.css';
-
-export type Command = {
-  name: string;
-  description: string;
-  commands?: Command[];
-};
 
 type Props = {
   parent?: string;
@@ -19,11 +14,30 @@ const CommandEl = ({ parent, cmd }: Props) => {
   const id = name.replace(/ /g, "_");
 
   return (
-    <div className={styles.cli}>
+    <div className={styles.cli} id={id}>
       <div className={styles.commandTitle}>
-        <a id={id} href={`#${id}`}>
-          <code>{name}</code>
-        </a>
+        <span>{name}</span>
+        {cmd.arg && (
+          <>
+            {" "}
+            {"<"}
+            <a href={`#arg-${cmd.arg.name}`}>{cmd.arg.name}</a>
+            {">"}
+          </>
+        )}
+
+        {cmd.args && (
+          <span>
+            {cmd.args.map((arg) => (
+              <>
+                {" "}
+                {"<"}
+                <a href={`#arg-${arg.name}`}>{arg.name}</a>
+                {">"}
+              </>
+            ))}
+          </span>
+        )}
       </div>
 
       <div dangerouslySetInnerHTML={{ __html: cmd.description }} />
@@ -50,6 +64,26 @@ const Cli = () => {
         {commands.map((cmd) => (
           <CommandEl cmd={cmd} parent="buf" />
         ))}
+      </div>
+
+      <div>
+        <h2>Arguments</h2>
+
+        <div>
+          {args.map((arg) => (
+            <div id={`arg-${arg.name}`}>
+              <code>{arg.name}</code>
+
+              <div dangerouslySetInnerHTML={{ __html: arg.description }} />
+
+              {arg.default && (
+                <p>
+                  Default: <code>{arg.default}</code>
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { commands } from './commands';
+import styles from './styles.module.css';
+
+export type Command = {
+  name: string;
+  description: string;
+  commands?: Command[];
+};
+
+type Props = {
+  parent?: string;
+  cmd: Command;
+};
+
+const CommandEl = ({ parent, cmd }: Props) => {
+  const name: string = parent ? `${parent} ${cmd.name}` : cmd.name;
+  const id = name.replace(/ /g, "_");
+
+  return (
+    <div className={styles.cli}>
+      <div className={styles.commandTitle}>
+        <a id={id} href={`#${id}`}>
+          <code>{name}</code>
+        </a>
+      </div>
+
+      <div dangerouslySetInnerHTML={{ __html: cmd.description }} />
+
+      {cmd.commands && (
+        <div className={styles.commandList}>
+          {cmd.commands.map((cmd) => (
+            <CommandEl cmd={cmd} parent={name} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Cli = () => {
+  return (
+    <div className={styles.cli}>
+      <p className={styles.title}>
+        The <code>buf</code> command-line interface
+      </p>
+
+      <div className={styles.commandList}>
+        {commands.map((cmd) => (
+          <CommandEl cmd={cmd} parent="buf" />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Cli;

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,22 +1,27 @@
-import React from "react";
+import React from 'react';
 
-import { args } from "./args";
-import Command, { commands } from "./commands";
-import styles from "./styles.module.css";
+import { args } from './args';
+import Command, { commands } from './commands';
+import styles from './styles.module.css';
 
 type Props = {
   parent?: string;
   cmd: Command;
 };
 
+const Html = ({ text }: { text: string }) => {
+  return <div dangerouslySetInnerHTML={{ __html: text }} />;
+};
+
 const CommandEl = ({ parent, cmd }: Props) => {
   const name: string = parent ? `${parent} ${cmd.name}` : cmd.name;
   const id = name.replace(/ /g, "_");
+  const href = `#${id}`;
 
   return (
     <div className={styles.cli} id={id}>
       <div className={styles.commandTitle}>
-        <a href={`#${id}`}>{name}</a>
+        <a href={href}>{name}</a>
 
         {cmd.arg && (
           <>
@@ -41,7 +46,7 @@ const CommandEl = ({ parent, cmd }: Props) => {
         )}
       </div>
 
-      <div dangerouslySetInnerHTML={{ __html: cmd.description }} />
+      <Html text={cmd.description} />
 
       {cmd.commands && (
         <div className={styles.commandList}>
@@ -77,7 +82,7 @@ const Cli = () => {
                 <code>{arg.name}</code>
               </a>
 
-              <div dangerouslySetInnerHTML={{ __html: arg.description }} />
+              <Html text={arg.description} />
 
               {arg.default && (
                 <p>

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -50,6 +50,54 @@ const Cmd = ({ parent, cmd }: CommandProps) => {
 
       <Html text={cmd.description} />
 
+      {cmd.flags && (
+        <table>
+          <thead>
+            <tr>
+              <th>Flag</th>
+              <th>Description</th>
+              <th>Options</th>
+              <th>Multiple?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cmd.flags.map((flag) => (
+              <tr>
+                <td>
+                  <code>{`--${flag.name}`}</code>
+                  {flag.short && (
+                    <>
+                      {", "}
+                      <code>{`-${flag.short}`}</code>
+                    </>
+                  )}
+                </td>
+                <td>
+                  <Html text={flag.description} />
+                </td>
+                <td>
+                  {flag.enum && (
+                    <table>
+                      <tbody>
+                        {Object.keys(flag.enum).map((key) => (
+                          <tr>
+                            <td>{flag.enum[key]}</td>
+                            <td>
+                              <code>{key}</code>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </td>
+                <td>{flag.multiple && <span>✅</span>}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
       {cmd.commands && (
         <div className={styles.commandList}>
           {cmd.commands.map((cmd) => (
@@ -58,42 +106,6 @@ const Cmd = ({ parent, cmd }: CommandProps) => {
         </div>
       )}
     </div>
-  );
-};
-
-const Argument = ({ name, description, argDefault }: Arg) => {
-  const id = `arg-${name}`;
-  const href = `#arg-${name}`;
-
-  return (
-    <>
-      <table>
-        <thead>
-          <tr>
-            <th>Argument</th>
-            <th>Description</th>
-            <th>Default</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-
-      <div id={id} className={styles.argument}>
-        <a href={href}>
-          <code>{name}</code>
-        </a>
-
-        <Html text={description} />
-
-        {argDefault && (
-          <div className={styles.default}>
-            <span>
-              Default: <code>{argDefault}</code>
-            </span>
-          </div>
-        )}
-      </div>
-    </>
   );
 };
 
@@ -107,7 +119,7 @@ const Cli = () => {
       </div>
 
       <div className={styles.arguments}>
-        <h2>Arguments</h2>
+        <h2>Available arguments</h2>
 
         <div>
           <table>

--- a/src/components/Cli/index.tsx
+++ b/src/components/Cli/index.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 
-import { args } from './args';
+import Arg, { args } from './args';
 import Command, { commands } from './commands';
 import styles from './styles.module.css';
 
-type Props = {
+type CommandProps = {
   parent?: string;
   cmd: Command;
 };
 
 const Html = ({ text }: { text: string }) => {
-  return <div dangerouslySetInnerHTML={{ __html: text }} />;
+  return <div className={styles.rawHtml} dangerouslySetInnerHTML={{ __html: text }} />;
 };
 
-const CommandEl = ({ parent, cmd }: Props) => {
+const Cmd = ({ parent, cmd }: CommandProps) => {
   const name: string = parent ? `${parent} ${cmd.name}` : cmd.name;
   const id = name.replace(/ /g, "_");
   const href = `#${id}`;
@@ -21,29 +21,31 @@ const CommandEl = ({ parent, cmd }: Props) => {
   return (
     <div className={styles.cli} id={id}>
       <div className={styles.commandTitle}>
-        <a href={href}>{name}</a>
+        <span className={styles.command}>
+          <a href={href}>{name}</a>
 
-        {cmd.arg && (
-          <>
-            {" "}
-            {"<"}
-            <a href={`#arg-${cmd.arg.name}`}>{cmd.arg.name}</a>
-            {">"}
-          </>
-        )}
+          {cmd.arg && (
+            <>
+              {" "}
+              {"<"}
+              <a href={`#arg-${cmd.arg.name}`}>{cmd.arg.name}</a>
+              {">"}
+            </>
+          )}
 
-        {cmd.args && (
-          <span>
-            {cmd.args.map((arg) => (
-              <>
-                {" "}
-                {"<"}
-                <a href={`#arg-${arg.name}`}>{arg.name}</a>
-                {">"}
-              </>
-            ))}
-          </span>
-        )}
+          {cmd.args && (
+            <span>
+              {cmd.args.map((arg) => (
+                <>
+                  {" "}
+                  {"<"}
+                  <a href={`#arg-${arg.name}`}>{arg.name}</a>
+                  {">"}
+                </>
+              ))}
+            </span>
+          )}
+        </span>
       </div>
 
       <Html text={cmd.description} />
@@ -51,7 +53,7 @@ const CommandEl = ({ parent, cmd }: Props) => {
       {cmd.commands && (
         <div className={styles.commandList}>
           {cmd.commands.map((cmd) => (
-            <CommandEl cmd={cmd} parent={name} />
+            <Cmd cmd={cmd} parent={name} />
           ))}
         </div>
       )}
@@ -59,41 +61,81 @@ const CommandEl = ({ parent, cmd }: Props) => {
   );
 };
 
+const Argument = ({ name, description, argDefault }: Arg) => {
+  const id = `arg-${name}`;
+  const href = `#arg-${name}`;
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Argument</th>
+            <th>Description</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+
+      <div id={id} className={styles.argument}>
+        <a href={href}>
+          <code>{name}</code>
+        </a>
+
+        <Html text={description} />
+
+        {argDefault && (
+          <div className={styles.default}>
+            <span>
+              Default: <code>{argDefault}</code>
+            </span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
 const Cli = () => {
   return (
-    <div className={styles.cli}>
-      <p className={styles.title}>
-        The <code>buf</code> command-line interface
-      </p>
-
+    <>
       <div className={styles.commandList}>
         {commands.map((cmd) => (
-          <CommandEl cmd={cmd} parent="buf" />
+          <Cmd cmd={cmd} parent="buf" />
         ))}
       </div>
 
-      <div>
+      <div className={styles.arguments}>
         <h2>Arguments</h2>
 
         <div>
-          {args.map((arg) => (
-            <div id={`arg-${arg.name}`}>
-              <a href={`#arg-${arg.name}`}>
-                <code>{arg.name}</code>
-              </a>
-
-              <Html text={arg.description} />
-
-              {arg.default && (
-                <p>
-                  Default: <code>{arg.default}</code>
-                </p>
-              )}
-            </div>
-          ))}
+          <table>
+            <thead>
+              <tr>
+                <th>Argument</th>
+                <th>Description</th>
+                <th>Default</th>
+              </tr>
+            </thead>
+            <tbody>
+              {args.map((arg) => (
+                <tr>
+                  <td>
+                    <a id={`arg-${arg.name}`}></a>
+                    <code>{arg.name}</code>
+                  </td>
+                  <td>
+                    <Html text={arg.description} />
+                  </td>
+                  <td>{arg.argDefault && <code>{arg.argDefault}</code>}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/Cli/links.ts
+++ b/src/components/Cli/links.ts
@@ -1,0 +1,13 @@
+const link = (name: string, text?: string): string => {
+  const txt = text ? text : name;
+  return `<a href="${links[name]}">${txt}</a>`;
+};
+
+const links: Record<string, string> = {
+  bsr: "/bsr/overview",
+  inputs: "/reference/inputs"
+};
+
+export {
+  link,
+}

--- a/src/components/Cli/links.ts
+++ b/src/components/Cli/links.ts
@@ -5,7 +5,8 @@ const link = (name: string, text?: string): string => {
 
 const links: Record<string, string> = {
   bsr: "/bsr/overview",
-  inputs: "/reference/inputs"
+  inputs: "/reference/inputs",
+  source: "#arg-source"
 };
 
 export { link };

--- a/src/components/Cli/links.ts
+++ b/src/components/Cli/links.ts
@@ -8,6 +8,4 @@ const links: Record<string, string> = {
   inputs: "/reference/inputs"
 };
 
-export {
-  link,
-}
+export { link };

--- a/src/components/Cli/styles.module.css
+++ b/src/components/Cli/styles.module.css
@@ -1,7 +1,10 @@
 .cli {
   border: 1px solid #ddd;
-  padding: 1rem;
+  padding: 0.75rem 1rem;
   border-radius: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .title {
@@ -16,4 +19,35 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+}
+
+.command {
+  font-family: var(--buf-mono-font);
+  background-color: #f3f4f6;
+  border-radius: 5px;
+  padding: 0.3rem 0.6rem;
+}
+
+.arguments {
+  margin-top: 2rem;
+}
+
+.argument {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+
+.argument + .argument {
+  border-top: 1px solid #ddd;
+}
+
+.default {
+  display: flex;
+  flex-flow: row-reverse;
+}
+
+.rawHtml {
+  font-size: 1.1rem;
 }

--- a/src/components/Cli/styles.module.css
+++ b/src/components/Cli/styles.module.css
@@ -1,0 +1,19 @@
+.cli {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  border-radius: 0.25rem;
+}
+
+.title {
+  font-size: 1.25rem;
+}
+
+.commandTitle {
+  font-size: 1.1rem;
+}
+
+.commandList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/components/Cli/styles.module.css
+++ b/src/components/Cli/styles.module.css
@@ -51,3 +51,8 @@
 .rawHtml {
   font-size: 1.1rem;
 }
+
+.option {
+  display: grid;
+  grid-auto-columns: auto;
+}

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -1,7 +1,7 @@
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import React from 'react';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import React from "react";
 
-import styles from './styles.module.css';
+import styles from "./styles.module.css";
 
 export const mac = "buf-Darwin-x86_64";
 export const linux = "buf-Linux-x86_64";

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import React from 'react';
 
-import styles from "./styles.module.css";
+import styles from './styles.module.css';
 
 export const mac = "buf-Darwin-x86_64";
 export const linux = "buf-Linux-x86_64";

--- a/vale/Vocab/Docs/accept.txt
+++ b/vale/Vocab/Docs/accept.txt
@@ -14,6 +14,7 @@ buildable
 celsius
 chmod
 classname
+cli
 cncf
 commandline
 config


### PR DESCRIPTION
Documentation for the Buf CLI is currently scattered throughout the usage documentation. This PR provides a single, reference-style page for the CLI that's heavily linkable from other places.

Preview: https://deploy-preview-126--buf.netlify.app/reference/cli