### PR TITLE
Add docs for BSR URLs

### DIFF
--- a/docs/bsr/remote-generation/concepts.md
+++ b/docs/bsr/remote-generation/concepts.md
@@ -75,7 +75,7 @@ import Syntax from "@site/src/components/Syntax";
   title="Synthetic version syntax"
   examples={["v1.3.5"]}
   segments={[
-    {label: "v1", kind: "static"},
+    {label: "v1", kind: "constant"},
     {separator: "."},
     {label: "template version", kind: "variable"},
     {separator: "."},

--- a/docs/bsr/remote-generation/go.md
+++ b/docs/bsr/remote-generation/go.md
@@ -29,7 +29,7 @@ import Syntax from "@site/src/components/Syntax";
 	title="Generated Go module path syntax"
 	examples={["go.buf.build/grpc/go/googleapis/googleapis"]}
 	segments={[
-	{"label": "go.buf.build", "kind": "static"},
+	{"label": "go.buf.build", "kind": "constant"},
 	{"separator": "/"},
 	{"label": "templateOwner", "kind": "variable"},
 	{"separator": "/"},

--- a/docs/bsr/remote-generation/npm.md
+++ b/docs/bsr/remote-generation/npm.md
@@ -39,7 +39,7 @@ import Syntax from "@site/src/components/Syntax";
   title="Syntax for BSR npm registry package names"
   examples={["@buf/protocolbuffers_js_acme_petapis"]}
   segments={[
-    {label: "@buf", kind: "static"},
+    {label: "@buf", kind: "constant"},
     {separator: "/"},
     {label: "templateOwner", kind: "variable"},
     {separator: "_"},
@@ -70,9 +70,9 @@ To install npm packages generated from private [Buf modules][modules], you need 
   examples={["//npm.buf.build/:_authToken=84612b6cbe8f4..."]}
   segments={[
     {separator: "//"},
-    {label: "npm.buf.build", kind: "static"},
+    {label: "npm.buf.build", kind: "constant"},
     {separator: "/:"},
-    {label: "_authToken", kind: "static"},
+    {label: "_authToken", kind: "constant"},
     {separator: "="},
     {label: "token", kind: "variable"},
   ]}

--- a/docs/bsr/usage.md
+++ b/docs/bsr/usage.md
@@ -3,8 +3,6 @@ id: usage
 title: Usage
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 To execute `buf` commands below make sure you are [authenticated](../bsr/authentication.md). Obtain a token from the BSR and run:
 
 ```terminal
@@ -174,3 +172,9 @@ Undeprecate a deprecated repository with
 ```terminal
 $ buf beta registry repository undeprecate <buf.build/owner/repository>
 ```
+
+## Buf Schema Registry URLs {#urls}
+
+import BsrUrls from "@site/src/components/BsrUrls";
+
+<BsrUrls />

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -50,7 +50,7 @@ to generate *with*:
 	title="Generated Go module path syntax"
 	examples={["go.buf.build/grpc/go/googleapis/googleapis"]}
 	segments={[
-    {"label": "go.buf.build", "kind": "static"},
+    {"label": "go.buf.build", "kind": "constant"},
     {"separator": "/"},
     {"label": "template owner", "kind": "variable"},
     {"separator": "/"},
@@ -204,7 +204,7 @@ import Syntax from "@site/src/components/Syntax";
   title="Synthetic version syntax"
   examples={["v1.3.5"]}
   segments={[
-    {label: "v1", kind: "static"},
+    {label: "v1", kind: "constant"},
     {separator: "."},
     {label: "template version", kind: "variable"},
     {separator: "."},

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -17,22 +17,40 @@ type SegmentProps = {
 
 type UrlProps = {
   title: string;
-  description: JSX.Element;
+  description?: JSX.Element;
+  docsPath?: string;
+  example?: string;
   segments: SegmentProps[];
 };
 
-const Url = ({ title, description, segments }: UrlProps) => {
+const Url = ({ title, description, docsPath, example, segments }: UrlProps) => {
   return (
     <div className={styles.urlContainer}>
-      <h4>{title}</h4>
+      <div className={styles.urlTitle}>
+        <h3>{title}</h3>
 
-      <div>{description}</div>
+        {docsPath && (
+          <span className={styles.docsPath}>
+            <Link to={docsPath}>docs</Link>
+          </span>
+        )}
+      </div>
+
+      {description}
 
       <div className={styles.url}>
         {segments.map((segment) => (
           <Segment key={segment.label ?? segment.separator} {...segment} />
         ))}
       </div>
+
+      {example && (
+        <div className={styles.example}>
+          <span>
+            Example: <Link to={example}>{example}</Link>
+          </span>
+        </div>
+      )}
     </div>
   );
 };
@@ -77,54 +95,47 @@ const slash: SegmentProps = {
   separator: "/"
 };
 
+const example = (path: string): string => {
+  return `https://buf.build/${path}`;
+};
+
 const urls: UrlProps[] = [
   {
-    title: "User",
-    description: (
-      <>
-        <Link to="/bsr/user-management">User</Link>
-      </>
-    ),
+    title: "User info",
+    docsPath: "/bsr/user-management",
+    example: example("bufbuild"),
     segments: [root, slash, variable("user")]
   },
   {
-    title: "Organization",
-    description: <></>,
+    title: "Organization info",
+    docsPath: "/bsr/user-management#organization-roles",
+    example: example("acme"),
     segments: [root, slash, variable("organization")]
   },
   {
-    title: "Repository",
+    title: "Members of an organization",
+    docsPath: "/bsr/user-management#organization-roles",
+    example: example("acme/members"),
     description: <></>,
-    segments: [root, slash, variable("repoName")]
+    segments: [root, slash, variable("organization"), slash, constant("members")]
   },
   {
-    title: "Templates",
+    title: "Organizations a user belongs to",
+    docsPath: "/bsr/user-management#organization-roles",
+    example: example("bufbot/organizations"),
     description: <></>,
-    segments: [
-      root,
-      slash,
-      variable("user|organization"),
-      slash,
-      constant("templates"),
-      slash,
-      variable("template")
-    ]
+    segments: [root, slash, variable("user"), slash, constant("organizations")]
   },
   {
-    title: "Plugins",
-    description: <></>,
-    segments: [
-      root,
-      slash,
-      variable("user|organization"),
-      slash,
-      constant("plugins"),
-      slash,
-      variable("plugin")
-    ]
+    title: "Module",
+    docsPath: "/bsr/user-management#organization-roles",
+    example: example("acme/paymentapis"),
+    segments: [root, slash, variable("user|organization"), slash, variable("module")]
   },
   {
     title: "Module documentation",
+    docsPath: "/bsr/overview#documentation",
+    example: example("acme/paymentapis/docs"),
     description: <></>,
     segments: [
       root,
@@ -138,6 +149,8 @@ const urls: UrlProps[] = [
   },
   {
     title: "Module code",
+    docsPath: "/bsr/overview#modules",
+    example: example("acme/paymentapis/tree"),
     description: <></>,
     segments: [
       root,
@@ -151,6 +164,8 @@ const urls: UrlProps[] = [
   },
   {
     title: "Module assets",
+    docsPath: "/bsr/overview#code-generation",
+    example: example("acme/paymentapis/assets"),
     description: <></>,
     segments: [
       root,
@@ -164,6 +179,8 @@ const urls: UrlProps[] = [
   },
   {
     title: "Module history",
+    docsPath: "/bsr/overview#referencing-a-module",
+    example: example("acme/paymentapis/history"),
     description: <></>,
     segments: [
       root,
@@ -176,14 +193,32 @@ const urls: UrlProps[] = [
     ]
   },
   {
-    title: "Organization members",
-    description: <></>,
-    segments: [root, slash, variable("organization"), slash, constant("members")]
+    title: "Templates associated with a user or organization",
+    docsPath: "/bsr/remote-generation/concepts#templates",
+    example: example("protocolbuffers/templates/go"),
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      constant("templates"),
+      slash,
+      variable("template")
+    ]
   },
   {
-    title: "User organizations",
-    description: <></>,
-    segments: [root, slash, variable("user"), slash, constant("organizations")]
+    title: "Plugins associated with a user or organization",
+    docsPath: "/bsr/remote-generation/concepts#plugins",
+    example: example("protocolbuffers/plugins/python"),
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      constant("plugins"),
+      slash,
+      variable("plugin")
+    ]
   }
 ];
 

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -227,7 +227,7 @@ const urls: UrlProps[] = [
   },
   {
     title: "Docs for a specific reference",
-    docsPath: "/bsr",
+    docsPath: "/bsr/overview#referencing-a-module",
     example: example("acme/paymentapis/docs/6e230f46113f498392c82d12b1a07b70"),
     segments: [
       root,
@@ -243,7 +243,7 @@ const urls: UrlProps[] = [
   },
   {
     title: "Code for a specific reference",
-    docsPath: "/bsr",
+    docsPath: "/bsr/overview#referencing-a-module",
     example: example("acme/paymentapis/tree/6e230f46113f498392c82d12b1a07b70"),
     segments: [
       root,
@@ -259,7 +259,7 @@ const urls: UrlProps[] = [
   },
   {
     title: "Generated assets for a specific reference",
-    docsPath: "/bsr",
+    docsPath: "/bsr/overview#referencing-a-module",
     example: example("acme/paymentapis/assets/6e230f46113f498392c82d12b1a07b70"),
     segments: [
       root,

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -13,7 +13,6 @@ type SegmentProps = {
   label?: string;
   kind?: Kind;
   separator?: string;
-  varName?: string;
 };
 
 type UrlProps = {
@@ -31,7 +30,7 @@ const Url = ({ title, description, segments }: UrlProps) => {
 
       <div className={styles.url}>
         {segments.map((segment) => (
-          <Segment {...segment} />
+          <Segment key={segment.label ?? segment.separator} {...segment} />
         ))}
       </div>
     </div>
@@ -192,7 +191,7 @@ const BsrUrls = () => {
   return (
     <div className={styles.urlsContainer}>
       {urls.map((url) => (
-        <Url {...url} />
+        <Url key={url.title} {...url} />
       ))}
     </div>
   );

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -163,7 +163,7 @@ const urls: UrlProps[] = [
     ]
   },
   {
-    title: "Module assets",
+    title: "Generated module assets",
     docsPath: "/bsr/overview#code-generation",
     example: example("acme/paymentapis/assets"),
     description: <></>,
@@ -218,6 +218,54 @@ const urls: UrlProps[] = [
       constant("plugins"),
       slash,
       variable("plugin")
+    ]
+  },
+  {
+    title: "Docs for a specific reference",
+    docsPath: "/bsr",
+    example: example("acme/paymentapis/docs/6e230f46113f498392c82d12b1a07b70"),
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("docs"),
+      slash,
+      variable("reference")
+    ]
+  },
+  {
+    title: "Code for a specific reference",
+    docsPath: "/bsr",
+    example: example("acme/paymentapis/tree/6e230f46113f498392c82d12b1a07b70"),
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("tree"),
+      slash,
+      variable("reference")
+    ]
+  },
+  {
+    title: "Generated assets for a specific reference",
+    docsPath: "/bsr",
+    example: example("acme/paymentapis/assets/6e230f46113f498392c82d12b1a07b70"),
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("assets"),
+      slash,
+      variable("reference")
     ]
   }
 ];

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -198,9 +198,9 @@ const urls: UrlProps[] = [
     ]
   },
   {
-    title: "Templates associated with a user or organization",
+    title: "Hosted template",
     docsPath: "/bsr/remote-generation/concepts#templates",
-    example: example("protocolbuffers/templates/go"),
+    example: example("protocolbuffers/templates/python"),
     segments: [
       root,
       slash,
@@ -212,7 +212,13 @@ const urls: UrlProps[] = [
     ]
   },
   {
-    title: "Plugins associated with a user or organization",
+    title: "Hosted templates associated with a user or organization",
+    docsPath: "/bsr/remote-generation/concepts#templates",
+    example: example("protocolbuffers/templates"),
+    segments: [root, slash, variable("user|organization"), slash, constant("templates")]
+  },
+  {
+    title: "Hosted plugin",
     docsPath: "/bsr/remote-generation/concepts#plugins",
     example: example("protocolbuffers/plugins/python"),
     segments: [
@@ -226,7 +232,13 @@ const urls: UrlProps[] = [
     ]
   },
   {
-    title: "Docs for a specific reference",
+    title: "Hosted plugins associated with a user or organization",
+    docsPath: "/bsr/remote-generation/concepts#plugins",
+    example: example("protocolbuffers/plugins"),
+    segments: [root, slash, variable("user|organization"), slash, constant("plugins")]
+  },
+  {
+    title: "Generated documentation for a specific reference",
     docsPath: "/bsr/overview#referencing-a-module",
     example: example("acme/paymentapis/docs/6e230f46113f498392c82d12b1a07b70"),
     segments: [

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -1,0 +1,201 @@
+import Link from '@docusaurus/Link';
+import React from 'react';
+
+import styles from './styles.module.css';
+
+enum Kind {
+  CONSTANT,
+  VARIABLE
+}
+
+// TODO: make this more idiomatic
+type SegmentProps = {
+  label?: string;
+  kind?: Kind;
+  separator?: string;
+  varName?: string;
+};
+
+type UrlProps = {
+  title: string;
+  description: JSX.Element;
+  segments: SegmentProps[];
+};
+
+const Url = ({ title, description, segments }: UrlProps) => {
+  return (
+    <div className={styles.urlContainer}>
+      <h4>{title}</h4>
+
+      <div>{description}</div>
+
+      <div className={styles.url}>
+        {segments.map((segment) => (
+          <Segment {...segment} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const Segment = ({ label, kind, separator }: SegmentProps) => {
+  let item: JSX.Element;
+  if (label !== undefined) {
+    switch (kind) {
+      case Kind.CONSTANT:
+        item = <span className={styles.constant}>{label}</span>;
+        break;
+      case Kind.VARIABLE:
+        item = (
+          <span className={styles.variable}>
+            {"{"}
+            {label}
+            {"}"}
+          </span>
+        );
+        break;
+    }
+  } else {
+    item = <span className={styles.separator}>{separator}</span>;
+  }
+  return item;
+};
+
+const root: SegmentProps = {
+  label: "https://buf.build",
+  kind: Kind.CONSTANT
+};
+
+const constant = (name: string): SegmentProps => {
+  return { label: name, kind: Kind.CONSTANT };
+};
+
+const variable = (name: string): SegmentProps => {
+  return { label: name, kind: Kind.VARIABLE };
+};
+
+const slash: SegmentProps = {
+  separator: "/"
+};
+
+const urls: UrlProps[] = [
+  {
+    title: "User",
+    description: (
+      <>
+        <Link to="/bsr/user-management">User</Link>
+      </>
+    ),
+    segments: [root, slash, variable("user")]
+  },
+  {
+    title: "Organization",
+    description: <></>,
+    segments: [root, slash, variable("organization")]
+  },
+  {
+    title: "Repository",
+    description: <></>,
+    segments: [root, slash, variable("repoName")]
+  },
+  {
+    title: "Templates",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      constant("templates"),
+      slash,
+      variable("template")
+    ]
+  },
+  {
+    title: "Plugins",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      constant("plugins"),
+      slash,
+      variable("plugin")
+    ]
+  },
+  {
+    title: "Module documentation",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("docs")
+    ]
+  },
+  {
+    title: "Module code",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("tree")
+    ]
+  },
+  {
+    title: "Module assets",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("assets")
+    ]
+  },
+  {
+    title: "Module history",
+    description: <></>,
+    segments: [
+      root,
+      slash,
+      variable("user|organization"),
+      slash,
+      variable("module"),
+      slash,
+      constant("history")
+    ]
+  },
+  {
+    title: "Organization members",
+    description: <></>,
+    segments: [root, slash, variable("organization"), slash, constant("members")]
+  },
+  {
+    title: "User organizations",
+    description: <></>,
+    segments: [root, slash, variable("user"), slash, constant("organizations")]
+  }
+];
+
+const BsrUrls = () => {
+  return (
+    <div className={styles.urlsContainer}>
+      {urls.map((url) => (
+        <Url {...url} />
+      ))}
+    </div>
+  );
+};
+
+export default BsrUrls;

--- a/src/components/BsrUrls/index.tsx
+++ b/src/components/BsrUrls/index.tsx
@@ -101,9 +101,14 @@ const example = (path: string): string => {
 
 const urls: UrlProps[] = [
   {
-    title: "User info",
+    title: "User settings",
     docsPath: "/bsr/user-management",
-    example: example("bufbuild"),
+    segments: [root, slash, constant("settings"), slash, constant("user")]
+  },
+  {
+    title: "User profile",
+    docsPath: "/bsr/user-management",
+    example: example("bufbot"),
     segments: [root, slash, variable("user")]
   },
   {

--- a/src/components/BsrUrls/styles.module.css
+++ b/src/components/BsrUrls/styles.module.css
@@ -1,0 +1,39 @@
+.urlsContainer {
+  border: 1.5px solid var(--buf-light-button-border-color);
+  border-radius: 0.25rem;
+}
+
+.urlsContainer h3,
+.urlsContainer h4,
+.urlsContainer p {
+  margin: 0;
+  padding: 0;
+}
+
+.urlContainer {
+  padding: 1rem;
+  border-top: 1.25px solid var(--buf-light-button-border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.url {
+  margin: 0;
+  padding: 0.5rem 1rem;
+  border-radius: 2px;
+  font-family: var(--ifm-font-family-monospace);
+  background-color: rgb(246, 248, 250);
+}
+
+.constant {
+  color: var(--syntax-color-static);
+}
+
+.variable {
+  color: var(--syntax-color-variable);
+}
+
+.separator {
+  color: var(--syntax-color-static);
+}

--- a/src/components/BsrUrls/styles.module.css
+++ b/src/components/BsrUrls/styles.module.css
@@ -12,13 +12,27 @@
 
 .urlContainer {
   padding: 1rem;
-  border-top: 1.25px solid var(--buf-light-button-border-color);
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
 }
 
+.urlContainer + .urlContainer {
+  border-top: 1.25px solid var(--buf-light-button-border-color);
+}
+
+.urlTitle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.docsPath {
+  font-size: 0.75rem;
+}
+
 .url {
+  font-size: 0.9rem;
   margin: 0;
   padding: 0.5rem 1rem;
   border-radius: 2px;
@@ -36,4 +50,10 @@
 
 .separator {
   color: var(--syntax-color-static);
+}
+
+.example {
+  display: flex;
+  flex-direction: row-reverse;
+  font-size: 0.8rem;
 }

--- a/src/components/Syntax/index.tsx
+++ b/src/components/Syntax/index.tsx
@@ -41,8 +41,8 @@ const Example = ({ examples }: { examples: string[] }) => {
 const Segment = ({ label, kind, separator, varName }: SegmentProps) => {
   let item: JSX.Element;
   switch (kind) {
-    case Kind.STATIC:
-      item = <span className={styles.static}>{label}</span>;
+    case Kind.CONSTANT:
+      item = <span className={styles.constant}>{label}</span>;
       break;
     case Kind.DEFAULT:
       item = (
@@ -74,7 +74,7 @@ const Legend = ({ segments }: { segments: SegmentProps[] }) => {
         <span>:</span>
       </span>
       <span className={styles.legendContent}>
-        {hasKind(segments, Kind.STATIC) && <span className={styles.static}>static</span>}
+        {hasKind(segments, Kind.CONSTANT) && <span className={styles.constant}>constant</span>}
         {hasKind(segments, Kind.DEFAULT) && (
           <span className={styles.default}>
             {"("}default{")"}

--- a/src/components/Syntax/index.tsx
+++ b/src/components/Syntax/index.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from 'react';
 
-import styles from "./styles.module.css";
+import styles from './styles.module.css';
 
 enum Kind {
-  STATIC = "static",
+  CONSTANT = "constant",
   DEFAULT = "default",
   VARIABLE = "variable"
 }
@@ -29,8 +29,8 @@ const Example = ({ examples }: { examples: string[] }) => {
   return (
     <div className={styles.examples}>
       {examples.length == 1 && (
-        <span>
-          Example:&nbsp;&nbsp;
+        <span className={styles.exampleTitle}>
+          <span>Example:</span>
           <span className={styles.example}>{examples[0]}</span>
         </span>
       )}

--- a/src/components/Syntax/styles.module.css
+++ b/src/components/Syntax/styles.module.css
@@ -57,8 +57,8 @@
   font-weight: 500;
 }
 
-.static {
-  color: var(--syntax-color-static);
+.constant {
+  color: var(--syntax-color-constant);
 }
 
 .default {

--- a/src/components/Syntax/styles.module.css
+++ b/src/components/Syntax/styles.module.css
@@ -47,7 +47,9 @@
   gap: 0.5rem;
 }
 
-.examples {
+.exampleTitle {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .example {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -68,7 +68,7 @@
   --ifm-color-warning: rgba(230, 126, 34, 0.1);
 
   /* Syntax widget */
-  --syntax-color-static: var(--ifm-color-gray);
+  --syntax-color-constant: var(--ifm-color-gray);
   --syntax-color-variable: var(--ifm-color-primary);
   --syntax-color-default: var(--ifm-color-orange);
 }

--- a/vale/Vocab/Docs/accept.txt
+++ b/vale/Vocab/Docs/accept.txt
@@ -136,10 +136,11 @@ Twirp
 Uber
 uname
 uncategorized
-Undeprecate
+undeprecate
 uniq
 unreferenced
-Uri
+uri
+urls
 usingcurl
 usr
 vendored


### PR DESCRIPTION
This PR adds a React component that shows the URL structure for navigating around the BSR. I feel like the concept could use some work so consider this a first pass.

Preview: https://deploy-preview-133--buf.netlify.app/bsr/usage#urls