### PR TITLE
Modify remote url in "list remote" doc

### DIFF
--- a/docs/tour/list-all-protobuf-files.md
+++ b/docs/tour/list-all-protobuf-files.md
@@ -22,7 +22,7 @@ necessary nor recommended.
 The `ls-files` command also works with remote inputs, such as this Git input:
 
 ```terminal
-$ buf ls-files git://github.com/bufbuild/buf-tour.git#branch=main,subdir=start/petapis
+$ buf ls-files https://github.com/bufbuild/buf-tour.git#branch=main,subdir=start/petapis
 ---
 start/petapis/google/type/datetime.proto
 start/petapis/pet/v1/pet.proto


### PR DESCRIPTION
Github does not accept git:// anymore - the command as is returns:

Failure: could not clone git://github.com/bufbuild/buf-tour.git: exit status 128
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.