### PR TITLE
Clarify JS + TS support

### DIFF
--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -39,7 +39,7 @@ Template | What it generates
 [`protocolbuffers/js`][pb-js] | JavaScript code stubs (`.js`)
 [`grpc/web`][grpc-web] | JavaScript code stubs (`.js`), TypeScript type definitions (`.d.ts`)
 
-In addition to these official templates, you can use any templates you like with npm&mdash;including templates that [you upload yourself](../remote-generation/template-example.md)&mdash;provided that those templates generate valid JavaScript and/or TypeScript code stubs. Templates that generate invalid JavaScript/TypeScript or other languages aren't supported. This operation, for example, would fail because the template, [`protocolbuffers/go`][pb-go], isn't supported:
+In addition to these official templates, you can use any templates you like with npm&mdash;including templates that [you upload yourself](../remote-generation/template-example.md)&mdash;provided that those templates generate valid JavaScript and/or TypeScript declaration files. Templates that generate invalid code aren't supported. This operation, for example, would fail because the template, [`protocolbuffers/go`][pb-go], isn't supported:
 
 ```terminal
 $ npm install @buf/protocol_buffers_go_acme_paymentapis

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -24,6 +24,22 @@ $ npm config set @buf:registry https://npm.buf.build
 
 This binds the `@buf` package scope to the BSR and updates your global [`.npmrc`][npmrc] accordingly.
 
+You can configure [Yarn] in an analogous way:
+
+```terminal
+$ yarn config set @buf:registry https://npm.buf.build
+```
+
+## Available templates
+
+The table below lists the generation [templates][template] that you can use with npm:
+
+Template | What it generates
+:--------|:-----------------
+[`protocolbuffers/js`][pb-js] | JavaScript
+[`grpc/web`][grpc-web] | JavaScript and TypeScript type definitions
+
+
 ## Installing packages {#install}
 
 With your npm config set, you can install `@buf/*` packages in any standard npm project. Here's an example installation command:
@@ -40,11 +56,12 @@ You may notice that installing packages from the BSR npm registry using `npm ins
 
 The BSR npm registry has a special syntax for package names that you need to adhere to when installing packages:
 
-import Syntax from "@site/src/components/Syntax";
-
 <Syntax
   title="Syntax for BSR npm registry package names"
-  examples={["@buf/protocolbuffers_js_acme_petapis"]}
+  examples={[
+    "@buf/protocolbuffers_js_acme_petapis",
+    "@buf/grpc_web_acme_paymentapis"
+  ]}
   segments={[
     {label: "@buf", kind: "constant"},
     {separator: "/"},
@@ -58,6 +75,8 @@ import Syntax from "@site/src/components/Syntax";
   ]
 } />
 
+
+
 In this example, the BSR npm registry generates the `@buf/protocolbuffers_js_acme_petapis` package applying the [`protocolbuffers/js`](https://buf.build/protocolbuffers/templates/js) template to the [`acme/petapis`](https://buf.build/acme/petapis) module.
 
 This table shows some example template/module/package name combinations:
@@ -67,6 +86,25 @@ Template | Buf module | Package name
 `grpc/web` | `acme/petapis` | `@buf/grpc_web_acme_petapis`
 `protocolbuffers/js` | `bufbuild/buf` | `@buf/protocolbuffers_js_bufbuild_buf`
 `protocolbuffers/js` | `acme/paymentapis` | `@buf/protocolbuffers_js_acme_paymentapis`
+
+## Package versions
+
+A **synthetic version** combines the [template](#templates) and [module](../overview.md#modules) versions into a [semantic version](https://semver.org/spec/v2.0.0.html) of this form:
+
+import Syntax from "@site/src/components/Syntax";
+
+<Syntax
+  title="Synthetic version syntax"
+  examples={["v1.3.5", "v1.2.26"]}
+  segments={[
+    {label: "v", kind: "constant"},
+    {label: "1", kind: "constant"},
+    {separator: "."},
+    {label: "templateVersion", kind: "variable"},
+    {separator: "."},
+    {label: "commitSequenceID", kind: "variable"},
+  ]
+} />
 
 ## Using private packages {#private}
 
@@ -131,12 +169,14 @@ If you're a plugin author, be sure to heed this naming structure; otherwise, con
 [bsr]: /bsr/overview
 [buf-npm]: https://npm.buf.build
 [deps]: /bsr/overview#dependencies
+[grpc-web]: https://buf.build/grpc/templates/web
 [javascript]: https://javascript.com
 [labels]: /bsr/remote-generation/plugin-example#3-prepare-the-dockerfile
 [modules]: /bsr/overview#modules
 [npm]: https://npmjs.org
 [npm-config]: https://docs.npmjs.com/cli/v8/commands/npm-config#set
 [npmrc]: https://docs.npmjs.com/cli/v8/configuring-npm/npmrc
+[pb-js]: https://buf.build/protocolbuffers/templates/js
 [plugins]: /bsr/remote-generation/concepts#plugins
 [protoc]: https://github.com/protocolbuffers/protobuf
 [pnpm]: https://pnpm.io

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -150,7 +150,7 @@ $ npm install @buf/protocolbuffers_js_acme_paymentapis@1.1.2
     {separator: "_"},
     {label: "moduleName", kind: "variable", href: "/bsr/overview#modules"},
     {separator: "@"},
-    {label: "syntheticVersion", kind: "variable", href: "/bsr/remote-generation/overview#synthetic-versions"}
+    {label: "packageVersion", kind: "variable"}
   ]}
 />
 

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -32,7 +32,7 @@ $ yarn config set @buf:registry https://npm.buf.build
 
 ## Available templates
 
-The table below lists the generation [templates][template] that you can use with npm:
+The table below lists the generation [templates](overview.md#templates) that you can use with npm:
 
 Template | What it generates
 :--------|:-----------------
@@ -88,8 +88,6 @@ Template | Buf module | Package name
 `protocolbuffers/js` | `acme/paymentapis` | `@buf/protocolbuffers_js_acme_paymentapis`
 
 ## Package versions
-
-A **synthetic version** combines the [template](#templates) and [module](../overview.md#modules) versions into a [semantic version](https://semver.org/spec/v2.0.0.html) of this form:
 
 import Syntax from "@site/src/components/Syntax";
 
@@ -177,7 +175,6 @@ If you're a plugin author, be sure to heed this naming structure; otherwise, con
 [npm-config]: https://docs.npmjs.com/cli/v8/commands/npm-config#set
 [npmrc]: https://docs.npmjs.com/cli/v8/configuring-npm/npmrc
 [pb-js]: https://buf.build/protocolbuffers/templates/js
-[plugins]: /bsr/remote-generation/concepts#plugins
 [protoc]: https://github.com/protocolbuffers/protobuf
 [pnpm]: https://pnpm.io
 [ranges]: https://docs.npmjs.com/cli/v6/using-npm/semver#ranges
@@ -185,7 +182,6 @@ If you're a plugin author, be sure to heed this naming structure; otherwise, con
 [registry-api]: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md
 [semver]: https://semver.org
 [settings]: https://buf.build/settings/user
-[template]: /bsr/remote-generation/concepts#templates
 [typescript]: https://typescript.org
 [yarn]: https://yarnpkg.com
 [yarn_v1]: https://github.com/yarnpkg/yarn/releases/tag/v1.10.0

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -32,12 +32,21 @@ $ yarn config set @buf:registry https://npm.buf.build
 
 ## Available templates {#templates}
 
-The table below lists the generation [templates](overview.md#templates) that you can use with npm:
+The table below lists the generation [templates](overview.md#templates) that are officially supported by the BSR:
 
 Template | What it generates
 :--------|:-----------------
 [`protocolbuffers/js`][pb-js] | JavaScript code stubs (`.js`)
 [`grpc/web`][grpc-web] | JavaScript code stubs (`.js`), TypeScript type definitions (`.d.ts`)
+
+In addition to these official templates, you can use any templates you like with npm&mdash;including templates that [you upload yourself](../remote-generation/template-example.md)&mdash;provided that those templates generate valid JavaScript and/or TypeScript code stubs. Templates that generate invalid JavaScript/TypeScript or other languages aren't supported. This operation, for example, would fail because the template, [`protocolbuffers/go`][pb-go], isn't supported:
+
+```terminal
+$ npm install @buf/protocol_buffers_go_acme_paymentapis
+---
+npm ERR! code E400
+npm ERR! 400 Bad Request - GET https://npm.buf.build/@buf%2fprotocol_buffers_go_acme_paymentapis
+```
 
 ## Installing packages {#install}
 
@@ -45,15 +54,6 @@ With your npm config [set](#setup), you can install `@buf/*` [packages](#package
 
 ```terminal
 $ npm install @buf/protocolbuffers_js_acme_paymentapis
-```
-
-You can use only the [supported templates](#templates) with npm. This operation, for example, would fail because the template, [`protocolbuffers/go`][pb-go], isn't supported:
-
-```terminal
-$ npm install @buf/protocol_buffers_go_acme_paymentapis
----
-npm ERR! code E400
-npm ERR! 400 Bad Request - GET https://npm.buf.build/@buf%2fprotocol_buffers_go_acme_paymentapis
 ```
 
 :::info Slow installation?

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -30,22 +30,30 @@ You can configure [Yarn] in an analogous way:
 $ yarn config set @buf:registry https://npm.buf.build
 ```
 
-## Available templates
+## Available templates {#templates}
 
 The table below lists the generation [templates](overview.md#templates) that you can use with npm:
 
 Template | What it generates
 :--------|:-----------------
-[`protocolbuffers/js`][pb-js] | JavaScript
-[`grpc/web`][grpc-web] | JavaScript and TypeScript type definitions
-
+[`protocolbuffers/js`][pb-js] | JavaScript code stubs (`.js`)
+[`grpc/web`][grpc-web] | JavaScript code stubs (`.js`), TypeScript type definitions (`.d.ts`)
 
 ## Installing packages {#install}
 
-With your npm config set, you can install `@buf/*` packages in any standard npm project. Here's an example installation command:
+With your npm config [set](#setup), you can install `@buf/*` [packages](#package-names) in any standard npm project. Here's an example installation command:
 
 ```terminal
 $ npm install @buf/protocolbuffers_js_acme_paymentapis
+```
+
+You can use only the [supported templates](#templates) with npm. This operation, for example, would fail because the template, [`protocolbuffers/go`][pb-go], isn't supported:
+
+```terminal
+$ npm install @buf/protocol_buffers_go_acme_paymentapis
+---
+npm ERR! code E400
+npm ERR! 400 Bad Request - GET https://npm.buf.build/@buf%2fprotocol_buffers_go_acme_paymentapis
 ```
 
 :::info Slow installation?
@@ -54,15 +62,17 @@ You may notice that installing packages from the BSR npm registry using `npm ins
 
 ## Package names
 
-The BSR npm registry has a special syntax for package names that you need to adhere to when installing packages:
+The BSR npm registry has a special syntax for package names:
 
 <Syntax
-  title="Syntax for BSR npm registry package names"
+  title="Syntax for package names"
   examples={[
-    "@buf/protocolbuffers_js_acme_petapis",
-    "@buf/grpc_web_acme_paymentapis"
+    "npm install @buf/protocolbuffers_js_acme_petapis",
+    "npm install @buf/grpc_web_acme_paymentapis"
   ]}
   segments={[
+    {label: "npm install", kind: "constant"},
+    {separator: " "},
     {label: "@buf", kind: "constant"},
     {separator: "/"},
     {label: "templateOwner", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
@@ -71,15 +81,13 @@ The BSR npm registry has a special syntax for package names that you need to adh
     {separator: "_"},
     {label: "moduleOwner", kind: "variable", href: "/bsr/overview#modules"},
     {separator: "_"},
-    {label: "moduleName", kind: "variable", href: "/bsr/overview#modules"},
+    {label: "moduleName", kind: "variable", href: "/bsr/overview#modules"}
   ]
 } />
 
+In the first example, `@buf/protocolbuffers_js_acme_petapis`, the BSR applies the [`protocolbuffers/js`](https://buf.build/protocolbuffers/templates/js) template to the [`acme/petapis`](https://buf.build/acme/petapis) module and thus generates JavaScript code stubs for the Protobuf definitions in that module.
 
-
-In this example, the BSR npm registry generates the `@buf/protocolbuffers_js_acme_petapis` package applying the [`protocolbuffers/js`](https://buf.build/protocolbuffers/templates/js) template to the [`acme/petapis`](https://buf.build/acme/petapis) module.
-
-This table shows some example template/module/package name combinations:
+This table shows some example template/module name combinations and the resulting package name:
 
 Template | Buf module | Package name
 :--------|:-----------|:------------
@@ -89,20 +97,62 @@ Template | Buf module | Package name
 
 ## Package versions
 
+By default, when you `npm install` a [Buf module][modules], the BSR generates code from the most recent [reference](../overview.md#referencing-a-module) for the module. But you can also install a specific package version using npm's standard `@` syntax:
+
+```terminal
+$ npm install @buf/protocolbuffers_js_acme_paymentapis@1.1.2
+```
+
+Package version syntax is based on the BSR's concept of [synthetic versions](overview.md#synthetic-versions):
+
 import Syntax from "@site/src/components/Syntax";
 
 <Syntax
-  title="Synthetic version syntax"
-  examples={["v1.3.5", "v1.2.26"]}
+  title="Package version syntax"
+  examples={["1.3.5", "1.2.26"]}
   segments={[
-    {label: "v", kind: "constant"},
     {label: "1", kind: "constant"},
     {separator: "."},
-    {label: "templateVersion", kind: "variable"},
+    {label: "templateVersion", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
     {separator: "."},
-    {label: "commitSequenceID", kind: "variable"},
+    {label: "commitSequenceID", kind: "variable", href: "/bsr/remote-generation/overview#commits"}
   ]
 } />
+
+With package versions:
+
+* The major version is always **1**.
+* The minor version (**3** in the first example) corresponds to the [template](overview.md#templates) version (without the `v` prefix). Template versions increase monotonically and have the form `v1`, `v2`, `v3`...
+* The patch version (**5** in the first example) corresponds to the module, which is identified by a [commit sequence ID](overview.md#commits) that's incremented each time a new version of a module is pushed.
+
+This command, for example, applies [version **1**][v1] of the [`protocolbuffers/js`][pb-js] template to a commit with an ID of **2** (the second commit pushed to the module):
+
+```terminal
+$ npm install @buf/protocolbuffers_js_acme_paymentapis@1.1.2
+```
+
+<Syntax
+  title="Specific version installation syntax"
+  examples={[
+    "npm install @buf/protocolbuffers_js_acme_paymentapis@1.1.2",
+    "npm install @buf/grpc_web_acme_petapis@1.2.1"
+  ]}
+  segments={[
+    {label: "npm install", kind: "constant"},
+    {separator: " "},
+    {label: "@buf", kind: "constant"},
+    {separator: "/"},
+    {label: "templateOwner", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
+    {separator: "_"},
+    {label: "templateName", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
+    {separator: "_"},
+    {label: "moduleOwner", kind: "variable", href: "/bsr/overview#modules"},
+    {separator: "_"},
+    {label: "moduleName", kind: "variable", href: "/bsr/overview#modules"},
+    {separator: "@"},
+    {label: "syntheticVersion", kind: "variable", href: "/bsr/remote-generation/overview#synthetic-versions"}
+  ]}
+/>
 
 ## Using private packages {#private}
 
@@ -174,6 +224,7 @@ If you're a plugin author, be sure to heed this naming structure; otherwise, con
 [npm]: https://npmjs.org
 [npm-config]: https://docs.npmjs.com/cli/v8/commands/npm-config#set
 [npmrc]: https://docs.npmjs.com/cli/v8/configuring-npm/npmrc
+[pb-go]: https://buf.build/protocolbuffers/templates/go
 [pb-js]: https://buf.build/protocolbuffers/templates/js
 [protoc]: https://github.com/protocolbuffers/protobuf
 [pnpm]: https://pnpm.io
@@ -183,6 +234,7 @@ If you're a plugin author, be sure to heed this naming structure; otherwise, con
 [semver]: https://semver.org
 [settings]: https://buf.build/settings/user
 [typescript]: https://typescript.org
+[v1]: https://buf.build/protocolbuffers/templates/js/v1
 [yarn]: https://yarnpkg.com
 [yarn_v1]: https://github.com/yarnpkg/yarn/releases/tag/v1.10.0
 [yarn_v2]: https://github.com/yarnpkg/berry

--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -150,7 +150,7 @@ import Syntax from "@site/src/components/Syntax";
 
 <Syntax
   title="Synthetic version syntax"
-  examples={["v1.3.5"]}
+  examples={["v1.3.5", "v1.2.26"]}
   segments={[
     {label: "v", kind: "constant"},
     {label: "1", kind: "constant"},

--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -5,7 +5,6 @@ description: The BSR supports remote code generation, which means you fetch gene
 ---
 
 import Breaking from "@site/src/components/Breaking";
-import BsrLanguages from "@site/src/components/BsrLanguages";
 
 <Breaking 
   feature="Remote code generation"
@@ -35,6 +34,7 @@ BSR itself_&mdash;not on your laptop, not in a CI/CD environment, only remotely 
 
 The BSR currently [supports](#registries) remote generation for these languages:
 
+import BsrLanguages from "@site/src/components/BsrLanguages";
 <BsrLanguages />
 
 We plan to support remote generation for additional languages in the near future.
@@ -118,10 +118,10 @@ members of the owner's organization.
 
 Buf maintains several official templates:
 
-- https://buf.build/protocolbuffers/templates/js
-- https://buf.build/protocolbuffers/templates/go
-- https://buf.build/grpc/templates/web
-- https://buf.build/grpc/templates/go
+- [`protocolbuffers/go`][pb-go]
+- [`protocolbuffers/js`][pb-js]
+- [`grpc/go`][grpc-go]
+- [`grpc/web`][grpc-web]
 
 A template **version** defines the plugin versions to use. This enables you to keep templates up to
 date with new versions of plugins in the template. A template version is of the form `v[1-9][0-9]*`.
@@ -211,8 +211,12 @@ In other words, we found that versions like `v1.2.3` were common whereas `v1.2.3
 and we opted for the former.
 
 [go-mod]: https://golang.org/ref/mod
+[grpc-go]: https://buf.build/grpc/templates/go
+[grpc-web]: https://buf.build/grpc/templates/web
 [hexadecimal]: https://en.wikipedia.org/wiki/Hexadecimal
 [npm]: https://npmjs.org
+[pb-go]: https://buf.build/protocolbuffers/templates/go
+[pb-js]: https://buf.build/protocolbuffers/templates/js
 [protoc-gen-go]: https://pkg.go.dev/google.golang.org/protobuf@v1.27.1/cmd/protoc-gen-go
 [protoc-gen-python]: https://developers.google.com/protocol-buffers/docs/reference/python-generated
 [scheme]: https://www.baeldung.com/cs/semantic-versioning#4-pre-release-and-build

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -202,13 +202,14 @@ import Syntax from "@site/src/components/Syntax";
 
 <Syntax
   title="Synthetic version syntax"
-  examples={["v1.3.5"]}
+  examples={["v1.3.5", "v1.2.26"]}
   segments={[
-    {label: "v1", kind: "constant"},
+    {label: "v", kind: "constant"},
+    {label: "1", kind: "constant"},
     {separator: "."},
-    {label: "template version", kind: "variable"},
+    {label: "templateVersion", kind: "variable"},
     {separator: "."},
-    {label: "commit sequence ID", kind: "variable"},
+    {label: "commitSequenceID", kind: "variable"},
   ]
 } />
 

--- a/src/components/Syntax/index.tsx
+++ b/src/components/Syntax/index.tsx
@@ -26,12 +26,25 @@ const hasKind = (segments: SegmentProps[], kind: Kind): boolean => {
 };
 
 const Example = ({ examples }: { examples: string[] }) => {
+  const multiple: boolean = examples.length > 1;
+
   return (
     <div className={styles.examples}>
-      {examples.length == 1 && (
-        <span className={styles.exampleTitle}>
-          <span>Example</span>
+      {!multiple && (
+        <span className={styles.exampleContainer}>
+          <span className={styles.exampleTitle}>Example</span>
           <span className={styles.example}>{examples[0]}</span>
+        </span>
+      )}
+
+      {multiple && (
+        <span className={styles.exampleContainer}>
+          <span className={styles.exampleTitle}>Examples</span>
+          <div className={styles.exampleList}>
+            {examples.map((example) => (
+              <span className={styles.example}>{example}</span>
+            ))}
+          </div>
         </span>
       )}
     </div>

--- a/src/components/Syntax/styles.module.css
+++ b/src/components/Syntax/styles.module.css
@@ -16,7 +16,7 @@
 .syntax {
   font-family: var(--ifm-font-family-monospace);
   font-size: 1rem;
-  border-radius: 0.25rem;
+  border-radius: 10px;
   background-color: rgb(246, 248, 250);
   letter-spacing: -0.05rem;
   border-radius: 0.2rem;
@@ -47,15 +47,26 @@
   gap: 0.5rem;
 }
 
-.exampleTitle {
+.exampleContainer {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
 }
 
 .example {
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.85rem;
+  margin-left: 0.5rem;
+}
+
+.exampleTitle {
+  font-weight: 600;
+  padding-bottom: 0.25rem;
+}
+
+.exampleList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 .constant {
@@ -73,5 +84,4 @@
 .separator {
   color: black;
   font-weight: 500;
-  padding: 0 0.05rem 0 0.05rem;
 }


### PR DESCRIPTION
This PR updates our remote code gen documentation for npm-based workflows. It adds a section on package versions and provides some other clarifications not present in the current doc.

Preview:

https://deploy-preview-145--buf.netlify.app/bsr/remote-generation/js