### PR TITLE
Add URLs to syntax widget segments

### DIFF
--- a/docs/bsr/overview.md
+++ b/docs/bsr/overview.md
@@ -30,13 +30,13 @@ import Syntax from "@site/src/components/Syntax";
   title="Module name syntax"
   examples={["buf.build/acme/weather"]}
   segments={[
-    {label: "buf.build", kind: "default", varName: "remote"},
+    {label: "buf.build", kind: "default"},
     {separator: "/"},
-    {label: "owner", kind: "variable"},
+    {label: "owner", kind: "variable", href: "/bsr/user-management#resource-owner"},
     {separator: "/"},
-    {label: "repository", kind: "variable"},
-  ]
-} />
+    {label: "repository", kind: "variable", href: "/bsr/overview#modules"},
+  ]}
+/>
 
 - **Remote**: The DNS name for the server hosting the BSR. This is always `buf.build`.
 - **Owner**: An entity that is either a user or organization within the BSR ecosystem.

--- a/docs/bsr/remote-generation/go.md
+++ b/docs/bsr/remote-generation/go.md
@@ -37,18 +37,21 @@ import Syntax from "@site/src/components/Syntax";
 
 <Syntax
 	title="Generated Go module path syntax"
-	examples={["go.buf.build/grpc/go/googleapis/googleapis"]}
+	examples={[
+		"go.buf.build/grpc/go/googleapis/googleapis"
+	]}
 	segments={[
-	{"label": "go.buf.build", "kind": "constant"},
-	{"separator": "/"},
-	{"label": "templateOwner", "kind": "variable"},
-	{"separator": "/"},
-	{"label": "templateName", "kind": "variable"},
-	{"separator": "/"},
-	{"label": "moduleOwner", "kind": "variable"},
-	{"separator": "/"},
-	{"label": "moduleName", "kind": "variable"},
-]} />
+		{"label": "go.buf.build", "kind": "constant"},
+		{"separator": "/"},
+		{"label": "templateOwner", "kind": "variable", href: "/bsr/remote-generation/overview#templates"},
+		{"separator": "/"},
+		{"label": "templateName", "kind": "variable", href: "/bsr/remote-generation/overview#templates"},
+		{"separator": "/"},
+		{"label": "moduleOwner", "kind": "variable", href: "/bsr/overview#modules"},
+		{"separator": "/"},
+		{"label": "moduleName", "kind": "variable", href: "/bsr/overview#modules"},
+	]}
+/>
 
 So if you wanted to, for example, generate the [`acme/paymentapis`][api] Protobuf module using the
 [`grpc/go`][grpc-go] template, you could install the generated code like this:

--- a/docs/bsr/remote-generation/js.md
+++ b/docs/bsr/remote-generation/js.md
@@ -48,13 +48,13 @@ import Syntax from "@site/src/components/Syntax";
   segments={[
     {label: "@buf", kind: "constant"},
     {separator: "/"},
-    {label: "templateOwner", kind: "variable"},
+    {label: "templateOwner", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
     {separator: "_"},
-    {label: "templateName", kind: "variable"},
+    {label: "templateName", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
     {separator: "_"},
-    {label: "moduleOwner", kind: "variable"},
+    {label: "moduleOwner", kind: "variable", href: "/bsr/overview#modules"},
     {separator: "_"},
-    {label: "moduleName", kind: "variable"},
+    {label: "moduleName", kind: "variable", href: "/bsr/overview#modules"},
   ]
 } />
 

--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -152,14 +152,13 @@ import Syntax from "@site/src/components/Syntax";
   title="Synthetic version syntax"
   examples={["v1.3.5"]}
   segments={[
-    {label: "v", kind: "constant"},
-    {label: "1", kind: "constant"},
+    {label: "v1", kind: "constant"},
     {separator: "."},
-    {label: "templateVersion", kind: "variable"},
+    {label: "templateVersion", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
     {separator: "."},
-    {label: "commitSequenceID", kind: "variable"},
-  ]
-} />
+    {label: "commitSequenceID", kind: "variable", href: "/bsr/remote-generation/overview#commits"},
+  ]}
+/>
 
 Within this scheme:
 

--- a/docs/bsr/user-management.md
+++ b/docs/bsr/user-management.md
@@ -7,18 +7,18 @@ title: User management
 
 Every user that is part of an organization has an explicit role. Note that users are unable to modify their own role. If you need to lower your access, have another organization user perform this action, or, leave the organization and request to be re-added with the desired role.
 	
-### Owner
+### Owner {#org-owner}
 
 - Users that require unrestricted access to the organization, its settings and all resources owned by the organization. 
 - Can delete organization. All resources such as repositories, templates and plugins must be deleted before the organization can be deleted.
 - Can add and delete resources such as [repositories](../bsr/overview.md#modules), [templates](../bsr/remote-generation/overview#templates) and [plugins](../bsr/remote-generation/overview#plugins).
 
-### Admin
+### Admin {#org-admin}
 
 - Can manage user roles, except owners.
 - Can add resources.
 
-### Member
+### Member {#org-member}
 
 - Can view the organization and its members.
 - Have the [Base resource role](#base-resource-roles) over the organizations resources, which defaults to [Write](#write).
@@ -30,7 +30,7 @@ The default roles:
 
 | Repository | Template | Plugin |
 |:--|:--|:--|
-| **Write**  | **Write** | **Write** |
+| Write  | Write | Write |
 
 Organization owners can modify the base resource roles depending on the requirements of the organization. These roles are configurable on the organization settings page.
 
@@ -47,23 +47,23 @@ The most common use-cases are:
 
 When computing the role on a resource, the highest role takes precedence. For example, an organization has **Write** as the base repository role, and the user was granted the **Admin** role on a specific repository. The final computed user role on the repository is **Admin**.
 
-### Owner
+### Owner {#resource-owner}
 
 - Unrestricted access to the resource.
 - Can delete the resource.
 
-### Admin
+### Admin {#resource-admin}
 
 - Can update the resource settings and deprecation notices.
 - Can manage resource roles, except owners.
 
-### Write
+### Write {#resource-write}
 
 - Can perform write operations on resources, such as:
   -  Pushing to a repository 
   -  Creating tags
   -  Updating template versions and plugins
 
-### Read
+### Read {#resource-read}
 
 - Can view the resource.

--- a/docs/lint/usage.md
+++ b/docs/lint/usage.md
@@ -70,8 +70,8 @@ import Syntax from "@site/src/components/Syntax";
     {label: "column", kind: "variable"},
     {separator: ":"},
     {label: "message", kind: "variable"}
-  ]
-} />
+  ]}
+/>
 
 Here's a full example output:
 

--- a/docs/tour/use-remote-generation.md
+++ b/docs/tour/use-remote-generation.md
@@ -59,8 +59,8 @@ to generate *with*:
     {"label": "module owner", "kind": "variable"},
     {"separator": "/"},
     {"label": "module name", "kind": "variable"},
-  ]
-} />
+  ]}
+/>
 
 With the module `buf.build/$BUF_USER/petapis` and template `buf.build/grpc/templates/go`, for example, the
 import path looks like this:
@@ -206,11 +206,11 @@ import Syntax from "@site/src/components/Syntax";
   segments={[
     {label: "v1", kind: "constant"},
     {separator: "."},
-    {label: "template version", kind: "variable"},
+    {label: "templateVersion", kind: "variable", href: "/bsr/remote-generation/overview#templates"},
     {separator: "."},
-    {label: "commit sequence ID", kind: "variable"},
-  ]
-} />
+    {label: "commitSequenceID", kind: "variable", href: "/bsr/remote-generation/overview#commits"},
+  ]}
+/>
 
 In the example above, the version `v1.3.5` represents the **3**rd version of a hosted template and the
 **5**th commit of a Protobuf module. In the example `go.mod` below, the `petapis` module uses

--- a/src/components/Syntax/index.tsx
+++ b/src/components/Syntax/index.tsx
@@ -12,7 +12,7 @@ type SegmentProps = {
   label: string;
   kind?: Kind;
   separator?: string;
-  varName?: string;
+  href?: string;
 };
 
 type Props = {
@@ -38,29 +38,47 @@ const Example = ({ examples }: { examples: string[] }) => {
   );
 };
 
-const Segment = ({ label, kind, separator, varName }: SegmentProps) => {
-  let item: JSX.Element;
+const Segment = ({ label, kind, separator, href }: SegmentProps) => {
+  let item: JSX.Element | undefined = undefined;
   switch (kind) {
     case Kind.CONSTANT:
       item = <span className={styles.constant}>{label}</span>;
       break;
     case Kind.DEFAULT:
-      item = (
-        <span className={styles.default}>
-          {`(${varName && `${varName}:`}`}
-          {label}
-          {")"}
-        </span>
-      );
+      item =
+        href != undefined ? (
+          <a href={href}>
+            <span className={styles.default}>
+              {"("}
+              {label}
+              {")"}
+            </span>
+          </a>
+        ) : (
+          <span className={styles.default}>
+            {"("}
+            {label}
+            {")"}
+          </span>
+        );
       break;
     case Kind.VARIABLE:
-      item = (
-        <span className={styles.variable}>
-          {"{"}
-          {label}
-          {"}"}
-        </span>
-      );
+      item =
+        href != undefined ? (
+          <a href={href}>
+            <span className={styles.variable}>
+              {"{"}
+              {label}
+              {"}"}
+            </span>
+          </a>
+        ) : (
+          <span className={styles.variable}>
+            {"{"}
+            {label}
+            {"}"}
+          </span>
+        );
       break;
   }
   return separator != undefined ? <span className={styles.separator}>{separator}</span> : item;

--- a/vale/Vocab/Docs/accept.txt
+++ b/vale/Vocab/Docs/accept.txt
@@ -51,6 +51,7 @@ grpcurl
 gz
 gzip
 hardcoding
+href
 html
 http
 https


### PR DESCRIPTION
This PR extends the `Syntax` widget to support `href` fields that make segments clickable