### PR TITLE
Use buf-setup-action to reference v1

### DIFF
--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v0.6.0
+      - uses: bufbuild/buf-setup-action@v1
 ```
 
 This ensures that `buf` is installed with the latest release version and is available for all subsequent steps
@@ -51,7 +51,7 @@ within the current job.
 To pin the `buf` CLI to a specific version, update your setup step to include a version:
 
 ```yaml {2-3}
-- uses: bufbuild/buf-setup-action@v0.6.0
+- uses: bufbuild/buf-setup-action@v1
   with:
     version: '1.3.1'
 ```
@@ -61,7 +61,7 @@ To resolve the latest release from GitHub, you can specify `latest`, but this is
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: bufbuild/buf-setup-action@v0.6.0
+  - uses: bufbuild/buf-setup-action@v1
     with:
       version: 'latest'
 ```
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v0.6.0
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
 ```
 
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v0.6.0
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v0.6.0
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
       - uses: bufbuild/buf-breaking-action@v1
         with:
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v0.6.0
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: 'proto'


### PR DESCRIPTION
Since we hit a stable `buf` cli `v1` the setup action should be stable as well.

Users have the option to pin using `with.version` .. but most users will probably just want `v1` latest.