### PR TITLE
Fix BsrLanguages import

### DIFF
--- a/docs/bsr/remote-generation/overview.md
+++ b/docs/bsr/remote-generation/overview.md
@@ -35,6 +35,7 @@ BSR itself_&mdash;not on your laptop, not in a CI/CD environment, only remotely 
 The BSR currently [supports](#registries) remote generation for these languages:
 
 import BsrLanguages from "@site/src/components/BsrLanguages";
+
 <BsrLanguages />
 
 We plan to support remote generation for additional languages in the near future.


### PR DESCRIPTION
Hi there! Congrats on the launch of BSR and remote generation, I've finally had a chance to give it a try. It is fantastic!
While reading the docs I found that the list of supported languages was blank and it looks like there was a syntax issue in the react component import.

Tested locally:
![image](https://user-images.githubusercontent.com/606459/170645912-26d9594e-31b8-4eaa-97d1-f071d1133644.png)
