### PR TITLE
Update highlighting to match diff

### DIFF
--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -29,7 +29,7 @@ $ rm -rf google
 
 Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../configuration/v1/buf-yaml.md):
 
-```yaml title="buf.yaml" {5-6}
+```yaml title="buf.yaml" {6-7}
  version: v1
  name: buf.build/$BUF_USER/petapis
  lint:
@@ -56,7 +56,7 @@ You can resolve this error by configuring a dependency in your `buf.yaml`'s
 [`deps`](/configuration/v1/buf-yaml#deps) key. The `google/type/datetime.proto` file is provided by
 the `buf.build/googleapis/googleapis` module, so you can configure it like this:
 
-```yaml title="buf.yaml" {2-3}
+```yaml title="buf.yaml" {3-4}
  version: v1
  name: buf.build/$BUF_USER/petapis
 +deps:
@@ -129,7 +129,7 @@ You can pin to a specific tag or commit by specifying it in your `deps` after th
 if you want to depend on the same commit you resolved above and prevent `buf` from updating it in the future,
 you can specify it like this:
 
-```yaml title="buf.yaml" {3-4}
+```yaml title="buf.yaml" {4-5}
  version: v1
  name: buf.build/$BUF_USER/petapis
  deps:
@@ -147,7 +147,7 @@ This is **not recommended** in general since you should _always_ be able to upda
 your dependencies if they remain backwards compatible. But in some situations it's unavoidable.
 With that said, restore the `buf.yaml` file to its previous state before you continue:
 
-```yaml title="buf.yaml" {3-4}
+```yaml title="buf.yaml" {4-5}
  version: v1
  name: buf.build/$BUF_USER/petapis
  deps:

--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -29,7 +29,7 @@ $ rm -rf google
 
 Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../configuration/v1/buf-yaml.md):
 
-```yaml title="buf.yaml" {6-7}
+```diff title="buf.yaml" 
  version: v1
  name: buf.build/$BUF_USER/petapis
  lint:

--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -29,7 +29,7 @@ $ rm -rf google
 
 Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../configuration/v1/buf-yaml.md):
 
-```diff title="buf.yaml" 
+```yaml title="buf.yaml" {6-7}
  version: v1
  name: buf.build/$BUF_USER/petapis
  lint:


### PR DESCRIPTION
Fixes TCN-163

The current version of this diff just updates the manual highlighting to be accurate, though we could replace the manual highlighting with the `diff` language rather than the `yaml` key. There is a slight formatting change. 

For now, I'm just going to update it to be consistent, but we should consider if we can deal with the `diff` formatting so as to not manually maintain line highlighting

<details>
<summary>Expand to see formatting differences</summary>
1. yaml formatting with manual Highlighting
`yaml title="buf.yaml" {6-7}`
<img width="570" alt="Screen Shot 2022-06-24 at 8 23 13 PM" src="https://user-images.githubusercontent.com/28396497/175750768-587dc147-df5b-4ef8-9ab2-2b39d1a0d900.png">

2. diff formatting (without yaml syntax highlighting)
`diff title="buf.yaml" ` 
<img width="485" alt="Screen Shot 2022-06-24 at 8 13 00 PM" src="https://user-images.githubusercontent.com/28396497/175750514-32a935a4-4852-4638-9e43-ec2b9b7f48f2.png">
</details>
