### PR TITLE
Missing directory according to the example

### DIFF
--- a/docs/configuration/v1/buf-gen-yaml.md
+++ b/docs/configuration/v1/buf-gen-yaml.md
@@ -78,8 +78,9 @@ tree
 │       └── v1
 │           └── pet.proto
 ├── gen
-│   └── go
-│       └── ...
+│   └── proto
+│       └── go
+│           └── ...
 ├── buf.gen.yaml
 ├── buf.lock
 └── buf.yaml


### PR DESCRIPTION
If I'm understanding correctly, in the example, this should be generated within `gen/proto/go`, right? https://docs.buf.build/configuration/v1/buf-gen-yaml#out