### PR TITLE
update buf.yaml default template to match current version `breaking`,  `lint` order

### DIFF
--- a/docs/breaking/usage.md
+++ b/docs/breaking/usage.md
@@ -18,12 +18,12 @@ $ buf mod init
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ## Run breaking change detection

--- a/docs/build/usage.md
+++ b/docs/build/usage.md
@@ -54,12 +54,12 @@ $ buf mod init
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ## Modules and workspaces

--- a/docs/configuration/v1/buf-yaml.md
+++ b/docs/configuration/v1/buf-yaml.md
@@ -20,6 +20,9 @@ name: ""
 deps: []
 build:
   excludes: []
+breaking:
+  use:
+    - FILE
 lint:
   use:
     - DEFAULT
@@ -28,9 +31,6 @@ lint:
   rpc_allow_google_protobuf_empty_requests: false
   rpc_allow_google_protobuf_empty_responses: false
   service_suffix: Service
-breaking:
-  use:
-    - FILE
 ```
 
 ## Fields

--- a/docs/configuration/v1beta1-migration-guide.md
+++ b/docs/configuration/v1beta1-migration-guide.md
@@ -20,12 +20,12 @@ build:
   roots:
     - proto
     - vendor/googleapis
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ```sh
@@ -103,22 +103,22 @@ roots can be defined as separate modules, as in these configurations:
 
 ```yaml title=proto/buf.yaml
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ```yaml title="vendor/googleapis/buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 The workspace is defined with a [`buf.work.yaml`](v1/buf-work-yaml.md), and makes it possible for users to consolidate multiple modules

--- a/docs/configuration/v1beta1/buf-yaml.md
+++ b/docs/configuration/v1beta1/buf-yaml.md
@@ -25,6 +25,9 @@ build:
   roots:
     - .
   excludes: []
+breaking:
+  use:
+    - FILE
 lint:
   use:
     - DEFAULT
@@ -33,9 +36,6 @@ lint:
   rpc_allow_google_protobuf_empty_requests: false
   rpc_allow_google_protobuf_empty_responses: false
   service_suffix: Service
-breaking:
-  use:
-    - FILE
 ```
 
 ## Fields

--- a/docs/generate/usage.md
+++ b/docs/generate/usage.md
@@ -34,12 +34,12 @@ $ buf mod init
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ## Create a `buf.gen.yaml`

--- a/docs/how-to/replace-protoc-with-buf.md
+++ b/docs/how-to/replace-protoc-with-buf.md
@@ -84,22 +84,22 @@ directories:
 
 ```yaml title="proto/buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ```yaml title="vendor/protoc-gen-validate/buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 The default `buf.yaml` configuration files shown above are created with this command:

--- a/docs/lint/usage.md
+++ b/docs/lint/usage.md
@@ -20,12 +20,12 @@ That creates this file:
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 As you can see, the default configuration applies the [`DEFAULT`](./rules.md#default) rules.

--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -29,7 +29,7 @@ $ rm -rf google
 
 Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../configuration/v1/buf-yaml.md):
 
-```yaml title="buf.yaml" {6-7}
+```yaml title="buf.yaml" {9-10}
  version: v1
  name: buf.build/$BUF_USER/petapis
  breaking:

--- a/docs/tour/add-a-dependency.md
+++ b/docs/tour/add-a-dependency.md
@@ -32,14 +32,14 @@ Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../
 ```yaml title="buf.yaml" {6-7}
  version: v1
  name: buf.build/$BUF_USER/petapis
+ breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
 -  ignore:
 -    - google/type/datetime.proto
- breaking:
-   use:
-     - FILE
 ```
 
 If you try to build the module in its current state, you will notice an error:
@@ -61,12 +61,12 @@ the `buf.build/googleapis/googleapis` module, so you can configure it like this:
  name: buf.build/$BUF_USER/petapis
 +deps:
 +  - buf.build/googleapis/googleapis
- lint:
-   use:
-     - DEFAULT
- breaking:
+breaking:
    use:
      - FILE
+ lint:
+   use:
+     - DEFAULT 
 ```
 
 Now, if you try to build the module again, you'll notice this:
@@ -135,12 +135,12 @@ you can specify it like this:
  deps:
 -  - buf.build/googleapis/googleapis
 +  - buf.build/googleapis/googleapis:62f35d8aed1149c291d606d958a7ce32
- lint:
-   use:
-     - DEFAULT
- breaking:
+breaking:
    use:
      - FILE
+ lint:
+   use:
+     - DEFAULT 
 ```
 
 This is **not recommended** in general since you should _always_ be able to update to the latest version of
@@ -153,12 +153,12 @@ With that said, restore the `buf.yaml` file to its previous state before you con
  deps:
 -  - buf.build/googleapis/googleapis:62f35d8aed1149c291d606d958a7ce32
 +  - buf.build/googleapis/googleapis
- lint:
-   use:
-     - DEFAULT
- breaking:
+breaking:
    use:
      - FILE
+ lint:
+   use:
+     - DEFAULT 
 ```
 
 ## 9.4 Push Your Changes {#push-your-changes}

--- a/docs/tour/configure-and-build.md
+++ b/docs/tour/configure-and-build.md
@@ -29,12 +29,12 @@ following content:
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 In `buf`'s default input mode, it assumes there is a `buf.yaml` in your current directory, or uses

--- a/docs/tour/detect-breaking-changes.md
+++ b/docs/tour/detect-breaking-changes.md
@@ -18,12 +18,12 @@ configuration. Your `buf.yaml` file currently has the `FILE` option configured:
 
 ```yaml title="buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 ## 4.1 Break Your API {#break-your-api}

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -48,7 +48,7 @@ The [`DEFAULT`](/lint/rules#default) lint category failures come from these rule
 To make `buf` happy, you can exclude these rules from the `DEFAULT` category by adding them to the
 [`except`](/lint/configuration#except) list in your lint configuration:
 
-```yaml title="buf.yaml" {5-8}
+```yaml title="buf.yaml" {8-11}
  version: v1
  breaking:
    use:

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -50,6 +50,9 @@ To make `buf` happy, you can exclude these rules from the `DEFAULT` category by 
 
 ```yaml title="buf.yaml" {5-8}
  version: v1
+ breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
@@ -57,9 +60,6 @@ To make `buf` happy, you can exclude these rules from the `DEFAULT` category by 
 +    - PACKAGE_VERSION_SUFFIX
 +    - FIELD_LOWER_SNAKE_CASE
 +    - SERVICE_SUFFIX
- breaking:
-   use:
-     - FILE
 ```
 
 Now if you run `buf lint` again, you'll notice that it's successful (exit code 0 and no output):
@@ -74,6 +74,9 @@ the lint failures. You can restore the `buf.yaml` to its previous state with the
 
 ```yaml title="buf.yaml" {5-8}
  version: v1
+ breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
@@ -81,9 +84,6 @@ the lint failures. You can restore the `buf.yaml` to its previous state with the
 -    - PACKAGE_VERSION_SUFFIX
 -    - FIELD_LOWER_SNAKE_CASE
 -    - SERVICE_SUFFIX
- breaking:
-   use:
-     - FILE
 ```
 
 ## 3.2 Fix lint failures {#fix-lint-failures}
@@ -133,14 +133,14 @@ file from `buf lint` like with this config update:
 
 ```yaml title="buf.yaml" {5-6}
  version: v1
+ breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
 +  ignore:
 +    - google/type/datetime.proto
- breaking:
-   use:
-     - FILE
 ```
 
 Alternatively, you can specify exactly which rules to ignore using the [`ignore_only`](/lint/configuration#ignore_only)

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -131,7 +131,7 @@ dependencies, provided by [googleapis](https://buf.build/googleapis/googleapis),
 `package` declaration to satisfy `buf`'s lint requirements. You can `ignore` the `google/type/datetime.proto`
 file from `buf lint` like with this config update:
 
-```yaml title="buf.yaml" {5-6}
+```yaml title="buf.yaml" {8-9}
  version: v1
  breaking:
    use:

--- a/docs/tour/lint-your-api.md
+++ b/docs/tour/lint-your-api.md
@@ -72,7 +72,7 @@ Silencing failures by eliminating lint rules using `except` is usually **not** r
 although it may be unavoidable in some situations; it's almost always better to actually _fix_
 the lint failures. You can restore the `buf.yaml` to its previous state with these config changes:
 
-```yaml title="buf.yaml" {5-8}
+```yaml title="buf.yaml" {8-11}
  version: v1
  breaking:
    use:

--- a/docs/tour/push-a-module.md
+++ b/docs/tour/push-a-module.md
@@ -65,12 +65,12 @@ Update your `buf.yaml` so that its `name` matches the repository you just create
 ```yaml title="buf.yaml" {2}
  version: v1
 +name: buf.build/$BUF_USER/petapis
+breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
- breaking:
-   use:
-     - FILE
 ```
 
 ## 7.4 Push the module {#push-the-module}

--- a/docs/tour/push-workspace-modules.md
+++ b/docs/tour/push-workspace-modules.md
@@ -82,12 +82,12 @@ $ cd ../petapis
  deps:
    - buf.build/googleapis/googleapis
 +  - buf.build/$BUF_USER/paymentapis
+breaking:
+   use:
+     - FILE
  lint:
    use:
      - DEFAULT
- breaking:
-   use:
-     - FILE
 ```
 
 Update your dependencies with this command:

--- a/docs/tour/use-a-workspace.md
+++ b/docs/tour/use-a-workspace.md
@@ -33,12 +33,12 @@ That creates this config file:
 
 ```yaml title="paymentapis/buf.yaml"
 version: v1
-lint:
-  use:
-    - DEFAULT
 breaking:
   use:
     - FILE
+lint:
+  use:
+    - DEFAULT
 ```
 
 You can also provide a `name` for the module:
@@ -46,12 +46,12 @@ You can also provide a `name` for the module:
 ```yaml title="paymentapis/buf.yaml" {2}
  version: v1
 +name: buf.build/$BUF_USER/paymentapis
- lint:
-   use:
-     - DEFAULT
- breaking:
+breaking:
    use:
      - FILE
+ lint:
+   use:
+     - DEFAULT 
 ```
 
 Now that the module is all set up, add an API:


### PR DESCRIPTION
in the documentation it's always mention that 

```yaml
version: v1
lint:
  use:
    - DEFAULT
breaking:
  use:
    - FILE
```


but in fact for today the generated buf.yaml looks like 
```yaml 
version: v1
breaking:
  use:
    - FILE
lint:
  use:
    - DEFAULT
```