### PR TITLE
Fix getting-started-with-bsr diffs - spacing && highlights

### DIFF
--- a/docs/tutorials/getting-started-with-bsr.md
+++ b/docs/tutorials/getting-started-with-bsr.md
@@ -254,7 +254,7 @@ $ rm -r google
 
 Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../configuration/v1/buf-yaml.md):
 
-```yaml title="buf.yaml" {6-7}
+```yaml title="buf.yaml" {9-10}
  version: v1
  name: buf.build/<USER>/petapis
  breaking:
@@ -263,8 +263,8 @@ Now remove the `google/type/datetime.proto` reference from your [`buf.yaml`](../
  lint:
    use:
      - DEFAULT
-     - ignore:
-     - - google/type/datetime.proto
+ -  ignore:
+ -    - google/type/datetime.proto
 ```
 
 If you try to build the module in its current state, you will notice an error:
@@ -285,7 +285,7 @@ configure it like this:
  version: v1
  name: buf.build/<USER>/petapis
  +deps:
-   +  - buf.build/googleapis/googleapis
+ +  - buf.build/googleapis/googleapis
  breaking:
    use:
      - FILE
@@ -389,21 +389,21 @@ $ rm -r gen
 
 Start by updating the `buf.gen.yaml` to exclude overriding any Go import statements related to googleapis.
 
-```yaml title="buf.gen.yaml"
+```yaml title="buf.gen.yaml {6-7,9-11}"
  version: v1
  managed:
    enabled: true
    go_package_prefix:
      default: github.com/bufbuild/buf-tour/petstore/gen
  +    except:
-   +      - buf.build/googleapis/googleapis
+ +      - buf.build/googleapis/googleapis
  plugins:
-   - plugin: buf.build/protocolbuffers/go
+ -  - plugin: buf.build/protocolbuffers/go
+ -    out: gen
+ -    opt: paths=source_relative
+   - plugin: buf.build/bufbuild/connect-go
      out: gen
      opt: paths=source_relative
-            - plugin: buf.build/bufbuild/connect-go
-            out: gen
-            opt: paths=source_relative
 ```
 
 ```terminal title="~/.../start/getting-started-with-bsr/"


### PR DESCRIPTION
As I was trying out the getting started guide, I was thrown for a momentary bit of a loop on the `getting-started-with-bsr` page. 

It seemed the indents were a bit off along with some other spacing inconsistencies when compared to the first page.

I especially had this issue [with the last diff/last change, furthest down](https://github.com/bufbuild/docs.buf.build/compare/main...HarderBetterFasterStronger:docs.buf.build:fix-bsr-page-diffs?expand=1#diff-df66aa50d8ed91f4b048a7f16e1c8cf503d84f5f74c49c09cba9895c8fd50013L401) removing the `buf.build/protocolbuffers/go` `plugin` from `buf.gen.yaml` where it seems maybe an indent auto-formatting issue happened, so I thought I would make a PR to help out.

My process to ensure I matched spacing and all - for each code block, 
- I interpreted the instructions' intentions and made the changes to each set of lines independenly
- ran a diff
- double checked that by removing the modifier (plus/minus symbol), the block would align as if uncommented
- copy/paste'd the result into the markdown
- ensured I matched other MD code blocks by prefixing each modified line in the MD code block with a single space
- ensured highlights for lines modified matched the actual lines being modified

I hope this helps our your team and others who are going through the getting started guide and am happy to make any modifications.

Thank you for developing this awesome tool!